### PR TITLE
Improve parsing for Go

### DIFF
--- a/swesmith/bug_gen/adapters/golang.py
+++ b/swesmith/bug_gen/adapters/golang.py
@@ -2,7 +2,7 @@ import re
 
 from swesmith.constants import TODO_REWRITE
 from swesmith.utils import CodeEntity
-from tree_sitter import Language, Parser
+from tree_sitter import Language, Parser, Query
 import tree_sitter_go as tsgo
 
 GO_LANGUAGE = Language(tsgo.language())
@@ -11,45 +11,65 @@ GO_LANGUAGE = Language(tsgo.language())
 class GoEntity(CodeEntity):
     @property
     def name(self) -> str:
-        if self.node.type == "function_declaration":
-            for child in self.node.children:
-                if child.type == "identifier":
-                    return child.text.decode("utf-8")
-        elif self.node.type == "method_declaration":
-            func_name, receiver_type = None, None
-            for child in self.node.children:
-                if child.type == "field_identifier":
-                    func_name = child.text.decode("utf-8")
-                elif child.type == "parameter_list":
-                    # Assume first parameter is the receiver
-                    receiver = [
-                        c for c in self.node.children if c.type == "parameter_list"
-                    ]
-                    receiver = [
-                        c
-                        for c in receiver[0].children
-                        if c.type == "parameter_declaration"
-                    ][0]
-                    type_node = [c for c in receiver.named_children if "type" in c.type]
-                    receiver_type = type_node[0].text.decode("utf-8").lstrip("*")
-            return f"{receiver_type}.{func_name}" if receiver_type else func_name
+        func_query = Query(
+            GO_LANGUAGE, "(function_declaration name: (identifier) @name)"
+        )
+        func_name = self._extract_text_from_first_match(func_query, self.node, "name")
+        if func_name:
+            return func_name
+
+        name_query = Query(
+            GO_LANGUAGE, "(method_declaration name: (field_identifier) @name)"
+        )
+        receiver_query = Query(
+            GO_LANGUAGE,
+            """
+            (method_declaration
+              receiver: (parameter_list
+                (parameter_declaration
+                  type: [
+                    (type_identifier) @receiver_type
+                    (pointer_type (type_identifier) @receiver_type)
+                  ])))
+            """.strip(),
+        )
+
+        func_name = self._extract_text_from_first_match(name_query, self.node, "name")
+        receiver_type = self._extract_text_from_first_match(
+            receiver_query, self.node, "receiver_type"
+        )
+
+        return (
+            f"{receiver_type}.{func_name}" if receiver_type and func_name else func_name
+        )
 
     @property
     def signature(self) -> str:
-        return self.src_code.split("{", 1)[0].strip()
+        body_query = Query(
+            GO_LANGUAGE,
+            """
+            [
+              (function_declaration body: (block) @body)
+              (method_declaration body: (block) @body)
+            ]
+            """.strip(),
+        )
+        matches = body_query.matches(self.node)
+        if matches:
+            body_node = matches[0][1]["body"][0]
+            body_start_byte = body_node.start_byte - self.node.start_byte
+            return self.src_code[:body_start_byte].strip()
+        return ""
 
     @property
     def stub(self) -> str:
-        # Find the opening brace '{' and remove everything after it
-        match = re.search(r"\{", self.src_code)
-        if match:
-            body_start = match.start()
-            return (
-                self.src_code[:body_start].rstrip() + " {\n\t// " + TODO_REWRITE + "\n}"
-            )
-        else:
-            # If no body found, return the original code
-            return self.src_code
+        return f"{self.signature} {{\n\t// {TODO_REWRITE}\n}}"
+
+    @staticmethod
+    def _extract_text_from_first_match(query, node, capture_name: str) -> str | None:
+        """Extract text from tree-sitter query matches with None fallback."""
+        matches = query.matches(node)
+        return matches[0][1][capture_name][0].text.decode("utf-8") if matches else None
 
 
 def get_entities_from_file_go(

--- a/tests/bug_gen/adapters/test_golang.py
+++ b/tests/bug_gen/adapters/test_golang.py
@@ -16,6 +16,25 @@ def test_get_entities_from_file_go_count(entities):
     assert len(entities) == 12
 
 
+def test_get_entities_from_file_go_max(test_file_go):
+    entities = []
+    get_entities_from_file_go(entities, test_file_go, 3)
+    assert len(entities) == 3
+
+
+def test_get_entities_from_file_go_unreadable():
+    with pytest.raises(IOError):
+        get_entities_from_file_go([], "non-existent-file")
+
+
+def test_get_entities_from_file_go_no_functions(tmp_path):
+    no_functions_file = tmp_path / "no_functions.go"
+    no_functions_file.write_text("// there are no functions here")
+    entities = []
+    get_entities_from_file_go(entities, no_functions_file)
+    assert len(entities) == 0
+
+
 def test_get_entities_from_file_go_names(entities):
     names = [e.name for e in entities]
     expected_names = [
@@ -90,6 +109,15 @@ def test_get_entities_from_file_go_signatures(entities):
         assert signature in signatures, (
             f"Expected signature '{signature}' not found in {signatures}"
         )
+
+
+def test_get_entities_from_file_go_signature_empty_interface(tmp_path):
+    empty_interface_arg_file = tmp_path / "empty_interface_arg.go"
+    empty_interface_arg_file.write_text("func TakesEmptyInterface(a interface{}) {}")
+    entities = []
+    get_entities_from_file_go(entities, empty_interface_arg_file)
+    assert len(entities) == 1
+    assert entities[0].signature == "func TakesEmptyInterface(a interface{})"
 
 
 def test_get_entities_from_file_go_stubs(entities):


### PR DESCRIPTION
* Use tree-sitter queries in the Go bug-gen adapter
* Determine the signature end in relation to the beginning of the function body rather than the first opening curly, see #38.