### PR TITLE
Python bug-gen adapter: Replace ast.Str with ast.Constant

### DIFF
--- a/swesmith/bug_gen/adapters/python.py
+++ b/swesmith/bug_gen/adapters/python.py
@@ -133,12 +133,12 @@ class PythonEntity(CodeEntity):
                 if (
                     node.body
                     and isinstance(node.body[0], ast.Expr)
-                    and isinstance(node.body[0].value, ast.Str)
+                    and isinstance(node.body[0].value, ast.Constant)
                 ):
                     new_node.body.append(node.body[0])
 
                 # Add a comment indicating to implement this function
-                new_node.body.append(ast.Expr(ast.Str(TODO_REWRITE)))
+                new_node.body.append(ast.Expr(ast.Constant(TODO_REWRITE)))
 
                 # Add a 'pass' statement after the docstring
                 new_node.body.append(ast.Pass())


### PR DESCRIPTION
**Fixing python adapter deprecation warnings**

- Deprecation warnings were shown when running tests on Python 3.12
- Seems reasonable to address them even if using 3.10 or 3.11
- See this issue for more info: https://github.com/python/cpython/issues/77073

Fixes:

```
swesmith/bug_gen/adapters/python.py:136: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
swesmith/bug_gen/adapters/python.py:141: DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
```

**Astor dependency**

A warning against the astor dependency will still be present after this PR is merged:

```
swesmith/lib/python3.12/site-packages/astor/op_util.py:92: DeprecationWarning: ast.Num is deprecated and will be removed in Python 3.14; use ast.Constant instead
    precedence_data = dict((getattr(ast, x, None), z) for x, y, z in op_data)
```

It looks like astor [hasn't been released since 2019](https://pypi.org/project/astor/).