### PR TITLE
Emit warning on Go parsing error

### DIFF
--- a/swesmith/bug_gen/adapters/golang.py
+++ b/swesmith/bug_gen/adapters/golang.py
@@ -4,6 +4,7 @@ from swesmith.constants import TODO_REWRITE
 from swesmith.utils import CodeEntity
 from tree_sitter import Language, Parser, Query
 import tree_sitter_go as tsgo
+import warnings
 
 GO_LANGUAGE = Language(tsgo.language())
 
@@ -91,6 +92,10 @@ def get_entities_from_file_go(
     def walk(node):
         # stop if we've hit the limit
         if 0 <= max_entities == len(entities):
+            return
+
+        if node.type == "ERROR":
+            warnings.warn(f"Error encountered parsing {file_path}")
             return
 
         if node.type in [

--- a/tests/bug_gen/adapters/test_golang.py
+++ b/tests/bug_gen/adapters/test_golang.py
@@ -1,4 +1,6 @@
 import pytest
+import re
+import warnings
 
 from swesmith.bug_gen.adapters.golang import (
     get_entities_from_file_go,
@@ -33,6 +35,21 @@ def test_get_entities_from_file_go_no_functions(tmp_path):
     entities = []
     get_entities_from_file_go(entities, no_functions_file)
     assert len(entities) == 0
+
+
+def test_get_entities_from_file_go_malformed(tmp_path):
+    malformed_file = tmp_path / "malformed.go"
+    malformed_file.write_text("(malformed")
+    entities = []
+    with warnings.catch_warnings(record=True) as ws:
+        warnings.simplefilter("always")
+        get_entities_from_file_go(entities, malformed_file)
+        assert any(
+            [
+                re.search(r"Error encountered parsing .*malformed.go", str(w.message))
+                for w in ws
+            ]
+        )
 
 
 def test_get_entities_from_file_go_names(entities):


### PR DESCRIPTION
Emit a warning when there's an issue parsing Go code, for consistency with the [Ruby adapter which has this behaviour](https://github.com/SWE-bench/SWE-smith/blob/91d74df1ef5a7014d0da0699cdf88e39f4f0b7b5/swesmith/bug_gen/adapters/ruby.py#L84-L86).