### PR TITLE
Support C bug generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "tiktoken",
     "tqdm",
     "tree-sitter>=0.23",
+    "tree-sitter-c==0.23.4",
     "tree-sitter-go",
     "tree-sitter-ruby",
     "tree-sitter-rust==v0.23.2",

--- a/swesmith/bug_gen/adapters/__init__.py
+++ b/swesmith/bug_gen/adapters/__init__.py
@@ -1,3 +1,6 @@
+from swesmith.bug_gen.adapters.c import (
+    get_entities_from_file_c,
+)
 from swesmith.bug_gen.adapters.golang import (
     get_entities_from_file_go,
 )
@@ -13,6 +16,7 @@ from swesmith.bug_gen.adapters.rust import (
 )
 
 get_entities_from_file = {
+    "c": get_entities_from_file_c,
     "go": get_entities_from_file_go,
     "php": get_entities_from_file_php,
     "py": get_entities_from_file_py,

--- a/swesmith/bug_gen/adapters/c.py
+++ b/swesmith/bug_gen/adapters/c.py
@@ -1,6 +1,5 @@
 import re
 import tree_sitter_c as tsc
-import warnings
 
 from swesmith.constants import TODO_REWRITE, CodeEntity
 from tree_sitter import Language, Parser, Query
@@ -68,9 +67,8 @@ def get_entities_from_file_c(
         if 0 <= max_entities == len(entities):
             return
 
-        if node.type == "ERROR":
-            warnings.warn(f"Error encountered parsing {file_path}")
-            return
+        # not checking for error nodes here because tree-sitter-c frequently
+        # generates them parsing valid processor directives
 
         if node.type == "function_definition":
             entities.append(_build_entity(node, lines, file_path))

--- a/swesmith/bug_gen/adapters/c.py
+++ b/swesmith/bug_gen/adapters/c.py
@@ -1,0 +1,118 @@
+import re
+import tree_sitter_c as tsc
+import warnings
+
+from swesmith.constants import TODO_REWRITE, CodeEntity
+from tree_sitter import Language, Parser, Query
+
+C_LANGUAGE = Language(tsc.language())
+
+
+class CEntity(CodeEntity):
+    @property
+    def name(self) -> str:
+        func_query = Query(
+            C_LANGUAGE,
+            "(function_definition (function_declarator declarator: (identifier) @name))",
+        )
+        func_name = self._extract_text_from_first_match(func_query, self.node, "name")
+        if func_name:
+            return func_name
+        return ""
+
+    @property
+    def signature(self) -> str:
+        body_query = Query(
+            C_LANGUAGE, "(function_definition body: (compound_statement) @body)"
+        )
+        matches = body_query.matches(self.node)
+        if matches:
+            body_node = matches[0][1]["body"][0]
+            body_start_byte = body_node.start_byte - self.node.start_byte
+            signature = self.node.text[:body_start_byte].strip().decode("utf-8")
+            return signature
+        return ""
+
+    @property
+    def stub(self) -> str:
+        return f"{self.signature} {{\n\t// {TODO_REWRITE}\n}}"
+
+    @staticmethod
+    def _extract_text_from_first_match(query, node, capture_name: str) -> str | None:
+        """Extract text from tree-sitter query matches with None fallback."""
+        matches = query.matches(node)
+        return matches[0][1][capture_name][0].text.decode("utf-8") if matches else None
+
+
+def get_entities_from_file_c(
+    entities: list[CEntity],
+    file_path: str,
+    max_entities: int = -1,
+) -> list[CEntity]:
+    """
+    Parse a .c file and return up to max_entities top-level funcs and types.
+    If max_entities < 0, collects them all.
+    """
+    parser = Parser(C_LANGUAGE)
+
+    file_content = open(file_path, "r", encoding="utf8").read()
+    tree = parser.parse(bytes(file_content, "utf8"))
+    root = tree.root_node
+    lines = file_content.splitlines()
+
+    def walk(node):
+        # stop if we've hit the limit
+        if 0 <= max_entities == len(entities):
+            return
+
+        if node.type == "ERROR":
+            warnings.warn(f"Error encountered parsing {file_path}")
+            return
+
+        if node.type == "function_definition":
+            entities.append(_build_entity(node, lines, file_path))
+            if 0 <= max_entities == len(entities):
+                return
+
+        for child in node.children:
+            walk(child)
+
+    walk(root)
+
+
+def _build_entity(node, lines, file_path: str) -> CodeEntity:
+    """
+    Turn a Tree-sitter node into CodeEntity.
+    """
+    # start_point/end_point are (row, col) zero-based
+    start_row, _ = node.start_point
+    end_row, _ = node.end_point
+
+    # slice out the raw lines
+    snippet = lines[start_row : end_row + 1]
+
+    # detect indent on first line
+    first = snippet[0]
+    m = re.match(r"^(?P<indent>[\t ]*)", first)
+    indent_str = m.group("indent")
+    # tabs count as size=1, else use count of spaces, fallback to 4
+    indent_size = 1 if "\t" in indent_str else (len(indent_str) or 4)
+    indent_level = len(indent_str) // indent_size
+
+    # dedent each line
+    dedented = []
+    for line in snippet:
+        if len(line) >= indent_level * indent_size:
+            dedented.append(line[indent_level * indent_size :])
+        else:
+            dedented.append(line.lstrip("\t "))
+
+    return CEntity(
+        file_path=file_path,
+        indent_level=indent_level,
+        indent_size=indent_size,
+        line_start=start_row + 1,
+        line_end=end_row + 1,
+        node=node,
+        src_code="\n".join(dedented),
+    )

--- a/swesmith/bug_gen/adapters/c.py
+++ b/swesmith/bug_gen/adapters/c.py
@@ -30,6 +30,9 @@ class CEntity(CodeEntity):
             body_node = matches[0][1]["body"][0]
             body_start_byte = body_node.start_byte - self.node.start_byte
             signature = self.node.text[:body_start_byte].strip().decode("utf-8")
+            signature = re.sub(r"\(\s+", "(", signature).strip()
+            signature = re.sub(r"\s+\)", ")", signature).strip()
+            signature = re.sub(r"\s+", " ", signature).strip()
             return signature
         return ""
 

--- a/swesmith/profiles/__init__.py
+++ b/swesmith/profiles/__init__.py
@@ -8,6 +8,7 @@ and provides a global registry for accessing all profiles.
 from .base import RepoProfile, global_registry
 
 # Auto-import all profile modules to populate the registry
+from . import c
 from . import java
 from . import php
 from . import python

--- a/swesmith/profiles/c.py
+++ b/swesmith/profiles/c.py
@@ -1,0 +1,112 @@
+import re
+
+from dataclasses import dataclass
+from swebench.harness.constants import TestStatus
+from swesmith.profiles.base import RepoProfile, global_registry
+
+
+@dataclass
+class CProfile(RepoProfile):
+    """
+    Profile for C repositories.
+    """
+
+
+@dataclass
+class Jqb9e19de76(CProfile):
+    owner: str = "jqlang"
+    repo: str = "jq"
+    commit: str = "b9e19de76e6e19d044007ead65d164710dc98877"
+    test_cmd: str = "make check"
+
+    @property
+    def dockerfile(self):
+        return f"""FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive \
+    DEBCONF_NONINTERACTIVE_SEEN=true \
+    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8
+ENV TZ=Etc/UTC
+RUN apt-get update \
+    && apt-get install -y build-essential autoconf libtool git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone https://github.com/{self.mirror_name} /testbed
+WORKDIR /testbed
+RUN git submodule update --init --recursive
+RUN autoreconf -i \
+    && ./configure \
+    --disable-docs \
+    --with-oniguruma=builtin \
+    --enable-static \
+    --enable-all-static \
+    --prefix=/usr/local
+RUN make clean
+RUN touch src/parser.y src/lexer.l
+RUN make -j$(nproc)
+"""
+
+    def log_parser(self, log: str) -> dict[str, str]:
+        test_status_map = {}
+        pattern = r"^\s*(PASS|FAIL):\s(.+)$"
+        for line in log.split("\n"):
+            match = re.match(pattern, line.strip())
+            if match:
+                status, test_name = match.groups()
+                if status == "PASS":
+                    test_status_map[test_name] = TestStatus.PASSED.value
+                elif status == "FAIL":
+                    test_status_map[test_name] = TestStatus.FAILED.value
+        return test_status_map
+
+
+@dataclass
+class Valkeyfc7c04e4(CProfile):
+    owner: str = "valkey-io"
+    repo: str = "valkey"
+    commit: str = "fc7c04e4f8ba86dfbac1ec059db457fb44ed0a2d"
+    test_cmd: str = "TERM=dumb ./runtest --durable"
+
+    @property
+    def dockerfile(self):
+        return f"""FROM ubuntu:22.04
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+RUN sed -i 's/^# deb-src/deb-src/' /etc/apt/sources.list
+RUN apt update && \
+    apt install -y pkg-config wget git build-essential libtool automake autoconf tcl bison flex cmake python3 python3-pip python3-venv python-is-python3 && \
+    rm -rf /var/lib/apt/lists/*
+RUN adduser --disabled-password --gecos 'dog' nonroot
+RUN git clone https://github.com/{self.mirror_name} /testbed
+WORKDIR /testbed
+RUN cd deps/jemalloc && ./autogen.sh
+RUN make distclean
+RUN make
+"""
+
+    def log_parser(self, log: str) -> dict[str, str]:
+        test_status_map = {}
+        pattern = r"^\[(ok|err|skip|ignore)\]:\s(.+?)(?:\s\((\d+\s*m?s)\))?$"
+        for line in log.split("\n"):
+            match = re.match(pattern, line.strip())
+            if match:
+                status, test_name, _duration = match.groups()
+                if status == "ok":
+                    test_status_map[test_name] = TestStatus.PASSED.value
+                elif status == "err":
+                    # Strip out file path information from failed test names
+                    test_name = re.sub(r"\s+in\s+\S+$", "", test_name)
+                    test_status_map[test_name] = TestStatus.FAILED.value
+                elif status == "skip" or status == "ignore":
+                    test_status_map[test_name] = TestStatus.SKIPPED.value
+        return test_status_map
+
+
+# Register all C profiles with the global registry
+for name, obj in list(globals().items()):
+    if (
+        isinstance(obj, type)
+        and issubclass(obj, CProfile)
+        and obj.__name__ != "CProfile"
+    ):
+        global_registry.register_profile(obj)

--- a/swesmith/profiles/golang.py
+++ b/swesmith/profiles/golang.py
@@ -1,6 +1,6 @@
 import re
-from dataclasses import dataclass
 
+from dataclasses import dataclass
 from swebench.harness.constants import TestStatus
 from swesmith.profiles.base import RepoProfile, global_registry
 

--- a/swesmith/profiles/java.py
+++ b/swesmith/profiles/java.py
@@ -52,7 +52,7 @@ RUN mvn clean install -B -pl gson -DskipTests -am
         return test_status_map
 
 
-# Register all Rust profiles with the global registry
+# Register all Java profiles with the global registry
 for name, obj in list(globals().items()):
     if (
         isinstance(obj, type)

--- a/tests/bug_gen/adapters/test_c.py
+++ b/tests/bug_gen/adapters/test_c.py
@@ -1,0 +1,152 @@
+import pytest
+import re
+import warnings
+
+from swesmith.bug_gen.adapters.c import (
+    get_entities_from_file_c,
+)
+
+
+@pytest.fixture
+def entities(test_file_c):
+    entities = []
+    get_entities_from_file_c(entities, test_file_c)
+    return entities
+
+
+def test_get_entities_from_file_c_count(entities):
+    assert len(entities) == 15
+
+
+def test_get_entities_from_file_c_max(test_file_c):
+    entities = []
+    get_entities_from_file_c(entities, test_file_c, 3)
+    assert len(entities) == 3
+
+
+def test_get_entities_from_file_c_unreadable():
+    with pytest.raises(IOError):
+        get_entities_from_file_c([], "non-existent-file")
+
+
+def test_get_entities_from_file_c_no_functions(tmp_path):
+    no_functions_file = tmp_path / "no_functions.c"
+    no_functions_file.write_text("// there are no functions here")
+    entities = []
+    get_entities_from_file_c(entities, no_functions_file)
+    assert len(entities) == 0
+
+
+def test_get_entities_from_file_c_malformed(tmp_path):
+    malformed_file = tmp_path / "malformed.c"
+    malformed_file.write_text("(malformed")
+    entities = []
+    with warnings.catch_warnings(record=True) as ws:
+        warnings.simplefilter("always")
+        get_entities_from_file_c(entities, malformed_file)
+        assert any(
+            [
+                re.search(r"Error encountered parsing .*malformed.c", str(w.message))
+                for w in ws
+            ]
+        )
+
+
+def test_get_entities_from_file_c_names(entities):
+    names = [e.name for e in entities]
+    expected_names = [
+        "restore_signals",
+        "isolate_child",
+        "spawn",
+        "print_usage",
+        "print_license",
+        "set_pdeathsig",
+        "add_expect_status",
+        "parse_args",
+        "parse_env",
+        "register_subreaper",
+        "reaper_check",
+        "configure_signals",
+        "wait_and_forward_signal",
+        "reap_zombies",
+        "main",
+    ]
+    assert names == expected_names
+
+
+def test_get_entities_from_file_c_line_ranges(entities):
+    start_end = [(e.line_start, e.line_end) for e in entities]
+    expected_ranges = [
+        (132, 149),
+        (151, 179),
+        (182, 225),
+        (227, 271),
+        (273, 281),
+        (283, 295),
+        (297, 313),
+        (315, 400),
+        (402, 419),
+        (423, 437),
+        (441, 460),
+        (463, 506),
+        (508, 546),
+        (548, 611),
+        (614, 688),
+    ]
+    assert start_end == expected_ranges
+
+
+def test_get_entities_from_file_c_extensions(entities):
+    assert all([e.ext == "c" for e in entities]), (
+        "All entities should have the extension 'c'"
+    )
+
+
+def test_get_entities_from_file_c_file_paths(entities, test_file_c):
+    assert all([e.file_path == test_file_c for e in entities]), (
+        "All entities should have the correct file path"
+    )
+
+
+def test_get_entities_from_file_c_signatures(entities):
+    signatures = [e.signature for e in entities]
+    expected_signatures = [
+        "int restore_signals(const signal_configuration_t* const sigconf_ptr)",
+        "int isolate_child(void)",
+        "int spawn(const signal_configuration_t* const sigconf_ptr, char* const argv[], int* const child_pid_ptr)",
+        "void print_usage(char* const name, FILE* const file)",
+        "void print_license(FILE* const file)",
+        "int set_pdeathsig(char* const arg)",
+        "int add_expect_status(char* arg)",
+        "int parse_args(const int argc, char* const argv[], char* (**child_args_ptr_ptr)[], int* const parse_fail_exitcode_ptr)",
+        "int parse_env(void)",
+        "int register_subreaper (void)",
+        "void reaper_check (void)",
+        "int configure_signals(sigset_t* const parent_sigset_ptr, const signal_configuration_t* const sigconf_ptr)",
+        "int wait_and_forward_signal(sigset_t const* const parent_sigset_ptr, pid_t const child_pid)",
+        "int reap_zombies(const pid_t child_pid, int* const child_exitcode_ptr)",
+        "int main(int argc, char *argv[])",
+    ]
+    assert signatures == expected_signatures
+
+
+def test_get_entities_from_file_c_stubs(entities):
+    stubs = [e.stub for e in entities]
+    expected_stubs = [
+        "int restore_signals(const signal_configuration_t* const sigconf_ptr) {\n\t// TODO: Implement this function\n}",
+        "int isolate_child(void) {\n\t// TODO: Implement this function\n}",
+        "int spawn(const signal_configuration_t* const sigconf_ptr, char* const argv[], int* const child_pid_ptr) {\n\t// TODO: Implement this function\n}",
+        "void print_usage(char* const name, FILE* const file) {\n\t// TODO: Implement this function\n}",
+        "void print_license(FILE* const file) {\n\t// TODO: Implement this function\n}",
+        "int set_pdeathsig(char* const arg) {\n\t// TODO: Implement this function\n}",
+        "int add_expect_status(char* arg) {\n\t// TODO: Implement this function\n}",
+        "int parse_args(const int argc, char* const argv[], char* (**child_args_ptr_ptr)[], int* const parse_fail_exitcode_ptr) {\n\t// TODO: Implement this function\n}",
+        "int parse_env(void) {\n\t// TODO: Implement this function\n}",
+        "int register_subreaper (void) {\n\t// TODO: Implement this function\n}",
+        "void reaper_check (void) {\n\t// TODO: Implement this function\n}",
+        "int configure_signals(sigset_t* const parent_sigset_ptr, const signal_configuration_t* const sigconf_ptr) {\n\t// TODO: Implement this function\n}",
+        "int wait_and_forward_signal(sigset_t const* const parent_sigset_ptr, pid_t const child_pid) {\n\t// TODO: Implement this function\n}",
+        "int reap_zombies(const pid_t child_pid, int* const child_exitcode_ptr) {\n\t// TODO: Implement this function\n}",
+        "int main(int argc, char *argv[]) {\n\t// TODO: Implement this function\n}",
+    ]
+    assert stubs == expected_stubs

--- a/tests/bug_gen/adapters/test_c.py
+++ b/tests/bug_gen/adapters/test_c.py
@@ -130,6 +130,17 @@ def test_get_entities_from_file_c_signatures(entities):
     assert signatures == expected_signatures
 
 
+def test_get_entities_from_file_c_multi_line_signature(tmp_path):
+    multi_line_signature_file = tmp_path / "multi_line_sig.c"
+    multi_line_signature_file.write_text(
+        "void multi_line(\n\tint a1,\n\tint a2,\n\tint a3\n)\n{\n}"
+    )
+    entities = []
+    get_entities_from_file_c(entities, multi_line_signature_file)
+    assert len(entities) == 1
+    assert entities[0].signature == "void multi_line(int a1, int a2, int a3)"
+
+
 def test_get_entities_from_file_c_stubs(entities):
     stubs = [e.stub for e in entities]
     expected_stubs = [

--- a/tests/bug_gen/adapters/test_c.py
+++ b/tests/bug_gen/adapters/test_c.py
@@ -1,6 +1,4 @@
 import pytest
-import re
-import warnings
 
 from swesmith.bug_gen.adapters.c import (
     get_entities_from_file_c,
@@ -35,21 +33,6 @@ def test_get_entities_from_file_c_no_functions(tmp_path):
     entities = []
     get_entities_from_file_c(entities, no_functions_file)
     assert len(entities) == 0
-
-
-def test_get_entities_from_file_c_malformed(tmp_path):
-    malformed_file = tmp_path / "malformed.c"
-    malformed_file.write_text("(malformed")
-    entities = []
-    with warnings.catch_warnings(record=True) as ws:
-        warnings.simplefilter("always")
-        get_entities_from_file_c(entities, malformed_file)
-        assert any(
-            [
-                re.search(r"Error encountered parsing .*malformed.c", str(w.message))
-                for w in ws
-            ]
-        )
 
 
 def test_get_entities_from_file_c_names(entities):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,18 @@ if repo_root not in sys.path:
 
 
 @pytest.fixture
+def test_file_c():
+    return Path(repo_root) / "tests/test_logs/files/c/tini.c"
+
+
+@pytest.fixture
 def test_file_go():
     return Path(repo_root) / "tests/test_logs/files/go/logger.go"
+
+
+@pytest.fixture
+def test_file_php():
+    return Path(repo_root) / "tests/test_logs/files/php/ControllerDispatcher.php"
 
 
 @pytest.fixture
@@ -28,11 +38,6 @@ def test_file_py():
 @pytest.fixture
 def test_file_ruby():
     return Path(repo_root) / "tests/test_logs/files/ruby/query_parser.rb"
-
-
-@pytest.fixture
-def test_file_php():
-    return Path(repo_root) / "tests/test_logs/files/php/ControllerDispatcher.php"
 
 
 @pytest.fixture

--- a/tests/test_logs/files/c/LICENSE
+++ b/tests/test_logs/files/c/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Thomas Orozco <thomas@orozco.fr>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tests/test_logs/files/c/tini.c
+++ b/tests/test_logs/files/c/tini.c
@@ -1,0 +1,688 @@
+/* See LICENSE file for copyright and license details. */
+#define _GNU_SOURCE
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/prctl.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <signal.h>
+#include <string.h>
+#include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <libgen.h>
+
+#include "tiniConfig.h"
+#include "tiniLicense.h"
+
+#if TINI_MINIMAL
+#define PRINT_FATAL(...)                         fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n");
+#define PRINT_WARNING(...)  if (verbosity > 0) { fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); }
+#define PRINT_INFO(...)     if (verbosity > 1) { fprintf(stdout, __VA_ARGS__); fprintf(stdout, "\n"); }
+#define PRINT_DEBUG(...)    if (verbosity > 2) { fprintf(stdout, __VA_ARGS__); fprintf(stdout, "\n"); }
+#define PRINT_TRACE(...)    if (verbosity > 3) { fprintf(stdout, __VA_ARGS__); fprintf(stdout, "\n"); }
+#define DEFAULT_VERBOSITY 0
+#else
+#define PRINT_FATAL(...)                         fprintf(stderr, "[FATAL tini (%i)] ", getpid()); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n");
+#define PRINT_WARNING(...)  if (verbosity > 0) { fprintf(stderr, "[WARN  tini (%i)] ", getpid()); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); }
+#define PRINT_INFO(...)     if (verbosity > 1) { fprintf(stdout, "[INFO  tini (%i)] ", getpid()); fprintf(stdout, __VA_ARGS__); fprintf(stdout, "\n"); }
+#define PRINT_DEBUG(...)    if (verbosity > 2) { fprintf(stdout, "[DEBUG tini (%i)] ", getpid()); fprintf(stdout, __VA_ARGS__); fprintf(stdout, "\n"); }
+#define PRINT_TRACE(...)    if (verbosity > 3) { fprintf(stdout, "[TRACE tini (%i)] ", getpid()); fprintf(stdout, __VA_ARGS__); fprintf(stdout, "\n"); }
+#define DEFAULT_VERBOSITY 1
+#endif
+
+#define ARRAY_LEN(x)  (sizeof(x) / sizeof((x)[0]))
+
+#define INT32_BITFIELD_SET(F, i)     ( F[(i / 32)] |=  (1 << (i % 32)) )
+#define INT32_BITFIELD_CLEAR(F, i)   ( F[(i / 32)] &= ~(1 << (i % 32)) )
+#define INT32_BITFIELD_TEST(F, i)    ( F[(i / 32)] &   (1 << (i % 32)) )
+#define INT32_BITFIELD_CHECK_BOUNDS(F, i) do {  assert(i >= 0); assert(ARRAY_LEN(F) > (uint) (i / 32)); } while(0)
+
+#define STATUS_MAX 255
+#define STATUS_MIN 0
+
+typedef struct {
+   sigset_t* const sigmask_ptr;
+   struct sigaction* const sigttin_action_ptr;
+   struct sigaction* const sigttou_action_ptr;
+} signal_configuration_t;
+
+static const struct {
+   char *const name;
+   int number;
+} signal_names[] = {
+   { "SIGHUP", SIGHUP },
+   { "SIGINT", SIGINT },
+   { "SIGQUIT", SIGQUIT },
+   { "SIGILL", SIGILL },
+   { "SIGTRAP", SIGTRAP },
+   { "SIGABRT", SIGABRT },
+   { "SIGBUS", SIGBUS },
+   { "SIGFPE", SIGFPE },
+   { "SIGKILL", SIGKILL },
+   { "SIGUSR1", SIGUSR1 },
+   { "SIGSEGV", SIGSEGV },
+   { "SIGUSR2", SIGUSR2 },
+   { "SIGPIPE", SIGPIPE },
+   { "SIGALRM", SIGALRM },
+   { "SIGTERM", SIGTERM },
+   { "SIGCHLD", SIGCHLD },
+   { "SIGCONT", SIGCONT },
+   { "SIGSTOP", SIGSTOP },
+   { "SIGTSTP", SIGTSTP },
+   { "SIGTTIN", SIGTTIN },
+   { "SIGTTOU", SIGTTOU },
+   { "SIGURG", SIGURG },
+   { "SIGXCPU", SIGXCPU },
+   { "SIGXFSZ", SIGXFSZ },
+   { "SIGVTALRM", SIGVTALRM },
+   { "SIGPROF", SIGPROF },
+   { "SIGWINCH", SIGWINCH },
+   { "SIGSYS", SIGSYS },
+};
+
+static unsigned int verbosity = DEFAULT_VERBOSITY;
+
+static int32_t expect_status[(STATUS_MAX - STATUS_MIN + 1) / 32];
+
+#ifdef PR_SET_CHILD_SUBREAPER
+#define HAS_SUBREAPER 1
+#define OPT_STRING "p:hvwgle:s"
+#define SUBREAPER_ENV_VAR "TINI_SUBREAPER"
+#else
+#define HAS_SUBREAPER 0
+#define OPT_STRING "p:hvwgle:"
+#endif
+
+#define VERBOSITY_ENV_VAR "TINI_VERBOSITY"
+#define KILL_PROCESS_GROUP_GROUP_ENV_VAR "TINI_KILL_PROCESS_GROUP"
+
+#define TINI_VERSION_STRING "tini version " TINI_VERSION TINI_GIT
+
+
+#if HAS_SUBREAPER
+static unsigned int subreaper = 0;
+#endif
+static unsigned int parent_death_signal = 0;
+static unsigned int kill_process_group = 0;
+
+static unsigned int warn_on_reap = 0;
+
+static struct timespec ts = { .tv_sec = 1, .tv_nsec = 0 };
+
+static const char reaper_warning[] = "Tini is not running as PID 1 "
+#if HAS_SUBREAPER
+       "and isn't registered as a child subreaper"
+#endif
+".\n\
+Zombie processes will not be re-parented to Tini, so zombie reaping won't work.\n\
+To fix the problem, "
+#if HAS_SUBREAPER
+#ifndef TINI_MINIMAL
+"use the -s option or "
+#endif
+"set the environment variable " SUBREAPER_ENV_VAR " to register Tini as a child subreaper, or "
+#endif
+"run Tini as PID 1.";
+
+int restore_signals(const signal_configuration_t* const sigconf_ptr) {
+	if (sigprocmask(SIG_SETMASK, sigconf_ptr->sigmask_ptr, NULL)) {
+		PRINT_FATAL("Restoring child signal mask failed: '%s'", strerror(errno));
+		return 1;
+	}
+
+	if (sigaction(SIGTTIN, sigconf_ptr->sigttin_action_ptr, NULL)) {
+		PRINT_FATAL("Restoring SIGTTIN handler failed: '%s'", strerror((errno)));
+		return 1;
+	}
+
+	if (sigaction(SIGTTOU, sigconf_ptr->sigttou_action_ptr, NULL)) {
+		PRINT_FATAL("Restoring SIGTTOU handler failed: '%s'", strerror((errno)));
+		return 1;
+	}
+
+	return 0;
+}
+
+int isolate_child(void) {
+	// Put the child into a new process group.
+	if (setpgid(0, 0) < 0) {
+		PRINT_FATAL("setpgid failed: %s", strerror(errno));
+		return 1;
+	}
+
+	// If there is a tty, allocate it to this new process group. We
+	// can do this in the child process because we're blocking
+	// SIGTTIN / SIGTTOU.
+
+	// Doing it in the child process avoids a race condition scenario
+	// if Tini is calling Tini (in which case the grandparent may make the
+	// parent the foreground process group, and the actual child ends up...
+	// in the background!)
+	if (tcsetpgrp(STDIN_FILENO, getpgrp())) {
+		if (errno == ENOTTY) {
+			PRINT_DEBUG("tcsetpgrp failed: no tty (ok to proceed)");
+		} else if (errno == ENXIO) {
+			// can occur on lx-branded zones
+			PRINT_DEBUG("tcsetpgrp failed: no such device (ok to proceed)");
+		} else {
+			PRINT_FATAL("tcsetpgrp failed: %s", strerror(errno));
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+
+int spawn(const signal_configuration_t* const sigconf_ptr, char* const argv[], int* const child_pid_ptr) {
+	pid_t pid;
+
+	// TODO: check if tini was a foreground process to begin with (it's not OK to "steal" the foreground!")
+
+	pid = fork();
+	if (pid < 0) {
+		PRINT_FATAL("fork failed: %s", strerror(errno));
+		return 1;
+	} else if (pid == 0) {
+
+		// Put the child in a process group and make it the foreground process if there is a tty.
+		if (isolate_child()) {
+			return 1;
+		}
+
+		// Restore all signal handlers to the way they were before we touched them.
+		if (restore_signals(sigconf_ptr)) {
+			return 1;
+		}
+
+		execvp(argv[0], argv);
+
+		// execvp will only return on an error so make sure that we check the errno
+		// and exit with the correct return status for the error that we encountered
+		// See: http://www.tldp.org/LDP/abs/html/exitcodes.html#EXITCODESREF
+		int status = 1;
+		switch (errno) {
+			case ENOENT:
+				status = 127;
+				break;
+			case EACCES:
+				status = 126;
+				break;
+		}
+		PRINT_FATAL("exec %s failed: %s", argv[0], strerror(errno));
+		return status;
+	} else {
+		// Parent
+		PRINT_INFO("Spawned child process '%s' with pid '%i'", argv[0], pid);
+		*child_pid_ptr = pid;
+		return 0;
+	}
+}
+
+void print_usage(char* const name, FILE* const file) {
+	char *dirc, *bname;
+
+	dirc = strdup(name);
+	bname = basename(dirc);
+
+	fprintf(file, "%s (%s)\n", bname, TINI_VERSION_STRING);
+
+#if TINI_MINIMAL
+	fprintf(file, "Usage: %s PROGRAM [ARGS] | --version\n\n", bname);
+#else
+	fprintf(file, "Usage: %s [OPTIONS] PROGRAM -- [ARGS] | --version\n\n", bname);
+#endif
+	fprintf(file, "Execute a program under the supervision of a valid init process (%s)\n\n", bname);
+
+	fprintf(file, "Command line options:\n\n");
+
+	fprintf(file, "  --version: Show version and exit.\n");
+
+#if TINI_MINIMAL
+#else
+	fprintf(file, "  -h: Show this help message and exit.\n");
+#if HAS_SUBREAPER
+	fprintf(file, "  -s: Register as a process subreaper (requires Linux >= 3.4).\n");
+#endif
+	fprintf(file, "  -p SIGNAL: Trigger SIGNAL when parent dies, e.g. \"-p SIGKILL\".\n");
+	fprintf(file, "  -v: Generate more verbose output. Repeat up to 3 times.\n");
+	fprintf(file, "  -w: Print a warning when processes are getting reaped.\n");
+	fprintf(file, "  -g: Send signals to the child's process group.\n");
+	fprintf(file, "  -e EXIT_CODE: Remap EXIT_CODE (from 0 to 255) to 0 (can be repeated).\n");
+	fprintf(file, "  -l: Show license and exit.\n");
+#endif
+
+	fprintf(file, "\n");
+
+	fprintf(file, "Environment variables:\n\n");
+#if HAS_SUBREAPER
+	fprintf(file, "  %s: Register as a process subreaper (requires Linux >= 3.4).\n", SUBREAPER_ENV_VAR);
+#endif
+	fprintf(file, "  %s: Set the verbosity level (default: %d).\n", VERBOSITY_ENV_VAR, DEFAULT_VERBOSITY);
+	fprintf(file, "  %s: Send signals to the child's process group.\n", KILL_PROCESS_GROUP_GROUP_ENV_VAR);
+
+	fprintf(file, "\n");
+	free(dirc);
+}
+
+void print_license(FILE* const file) {
+    if(LICENSE_len > fwrite(LICENSE, sizeof(char), LICENSE_len, file)) {
+        // Don't handle this error for now, since parse_args won't care
+        // about the return value. We do need to check it to compile with
+        // older glibc, though.
+        // See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25509
+        // See: http://sourceware.org/bugzilla/show_bug.cgi?id=11959
+    }
+}
+
+int set_pdeathsig(char* const arg) {
+	size_t i;
+
+	for (i = 0; i < ARRAY_LEN(signal_names); i++) {
+		if (strcmp(signal_names[i].name, arg) == 0) {
+			/* Signals start at value "1" */
+			parent_death_signal = signal_names[i].number;
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+int add_expect_status(char* arg) {
+	long status = 0;
+	char* endptr = NULL;
+	status = strtol(arg, &endptr, 10);
+
+	if ((endptr == NULL) || (*endptr != 0)) {
+		return 1;
+	}
+
+	if ((status < STATUS_MIN) || (status > STATUS_MAX)) {
+		return 1;
+	}
+
+	INT32_BITFIELD_CHECK_BOUNDS(expect_status, status);
+	INT32_BITFIELD_SET(expect_status, status);
+	return 0;
+}
+
+int parse_args(const int argc, char* const argv[], char* (**child_args_ptr_ptr)[], int* const parse_fail_exitcode_ptr) {
+	char* name = argv[0];
+
+	// We handle --version if it's the *only* argument provided.
+	if (argc == 2 && strcmp("--version", argv[1]) == 0) {
+		*parse_fail_exitcode_ptr = 0;
+		fprintf(stdout, "%s\n", TINI_VERSION_STRING);
+		return 1;
+	}
+
+#ifndef TINI_MINIMAL
+	int c;
+	while ((c = getopt(argc, argv, OPT_STRING)) != -1) {
+		switch (c) {
+			case 'h':
+				print_usage(name, stdout);
+				*parse_fail_exitcode_ptr = 0;
+				return 1;
+#if HAS_SUBREAPER
+			case 's':
+				subreaper++;
+				break;
+#endif
+			case 'p':
+				if (set_pdeathsig(optarg)) {
+					PRINT_FATAL("Not a valid option for -p: %s", optarg);
+					*parse_fail_exitcode_ptr = 1;
+					return 1;
+				}
+				break;
+
+			case 'v':
+				verbosity++;
+				break;
+
+			case 'w':
+				warn_on_reap++;
+				break;
+
+			case 'g':
+				kill_process_group++;
+				break;
+
+			case 'e':
+				if (add_expect_status(optarg)) {
+					PRINT_FATAL("Not a valid option for -e: %s", optarg);
+					*parse_fail_exitcode_ptr = 1;
+					return 1;
+				}
+				break;
+
+			case 'l':
+				print_license(stdout);
+				*parse_fail_exitcode_ptr = 0;
+				return 1;
+
+			case '?':
+				print_usage(name, stderr);
+				return 1;
+			default:
+				/* Should never happen */
+				return 1;
+		}
+	}
+#endif
+
+	*child_args_ptr_ptr = calloc(argc-optind+1, sizeof(char*));
+	if (*child_args_ptr_ptr == NULL) {
+		PRINT_FATAL("Failed to allocate memory for child args: '%s'", strerror(errno));
+		return 1;
+	}
+
+	int i;
+	for (i = 0; i < argc - optind; i++) {
+		(**child_args_ptr_ptr)[i] = argv[optind+i];
+	}
+	(**child_args_ptr_ptr)[i] = NULL;
+
+	if (i == 0) {
+		/* User forgot to provide args! */
+		print_usage(name, stderr);
+		return 1;
+	}
+
+	return 0;
+}
+
+int parse_env(void) {
+#if HAS_SUBREAPER
+	if (getenv(SUBREAPER_ENV_VAR) != NULL) {
+		subreaper++;
+	}
+#endif
+
+	if (getenv(KILL_PROCESS_GROUP_GROUP_ENV_VAR) != NULL) {
+		kill_process_group++;
+	}
+
+	char* env_verbosity = getenv(VERBOSITY_ENV_VAR);
+	if (env_verbosity != NULL) {
+		verbosity = atoi(env_verbosity);
+	}
+
+	return 0;
+}
+
+
+#if HAS_SUBREAPER
+int register_subreaper (void) {
+	if (subreaper > 0) {
+		if (prctl(PR_SET_CHILD_SUBREAPER, 1)) {
+			if (errno == EINVAL) {
+				PRINT_FATAL("PR_SET_CHILD_SUBREAPER is unavailable on this platform. Are you using Linux >= 3.4?")
+			} else {
+				PRINT_FATAL("Failed to register as child subreaper: %s", strerror(errno))
+			}
+			return 1;
+		} else {
+			PRINT_TRACE("Registered as child subreaper");
+		}
+	}
+	return 0;
+}
+#endif
+
+
+void reaper_check (void) {
+	/* Check that we can properly reap zombies */
+#if HAS_SUBREAPER
+	int bit = 0;
+#endif
+
+	if (getpid() == 1) {
+		return;
+	}
+
+#if HAS_SUBREAPER
+	if (prctl(PR_GET_CHILD_SUBREAPER, &bit)) {
+		PRINT_DEBUG("Failed to read child subreaper attribute: %s", strerror(errno));
+	} else if (bit == 1) {
+		return;
+	}
+#endif
+
+	PRINT_WARNING(reaper_warning);
+}
+
+
+int configure_signals(sigset_t* const parent_sigset_ptr, const signal_configuration_t* const sigconf_ptr) {
+	/* Block all signals that are meant to be collected by the main loop */
+	if (sigfillset(parent_sigset_ptr)) {
+		PRINT_FATAL("sigfillset failed: '%s'", strerror(errno));
+		return 1;
+	}
+
+	// These ones shouldn't be collected by the main loop
+	uint i;
+	int signals_for_tini[] = {SIGFPE, SIGILL, SIGSEGV, SIGBUS, SIGABRT, SIGTRAP, SIGSYS, SIGTTIN, SIGTTOU};
+	for (i = 0; i < ARRAY_LEN(signals_for_tini); i++) {
+		if (sigdelset(parent_sigset_ptr, signals_for_tini[i])) {
+			PRINT_FATAL("sigdelset failed: '%i'", signals_for_tini[i]);
+			return 1;
+		}
+	}
+
+	if (sigprocmask(SIG_SETMASK, parent_sigset_ptr, sigconf_ptr->sigmask_ptr)) {
+		PRINT_FATAL("sigprocmask failed: '%s'", strerror(errno));
+		return 1;
+	}
+
+	// Handle SIGTTIN and SIGTTOU separately. Since Tini makes the child process group
+	// the foreground process group, there's a chance Tini can end up not controlling the tty.
+	// If TOSTOP is set on the tty, this could block Tini on writing debug messages. We don't
+	// want that. Ignore those signals.
+	struct sigaction ign_action;
+	memset(&ign_action, 0, sizeof ign_action);
+
+	ign_action.sa_handler = SIG_IGN;
+	sigemptyset(&ign_action.sa_mask);
+
+	if (sigaction(SIGTTIN, &ign_action, sigconf_ptr->sigttin_action_ptr)) {
+		PRINT_FATAL("Failed to ignore SIGTTIN");
+		return 1;
+	}
+
+	if (sigaction(SIGTTOU, &ign_action, sigconf_ptr->sigttou_action_ptr)) {
+		PRINT_FATAL("Failed to ignore SIGTTOU");
+		return 1;
+	}
+
+	return 0;
+}
+
+int wait_and_forward_signal(sigset_t const* const parent_sigset_ptr, pid_t const child_pid) {
+	siginfo_t sig;
+
+	if (sigtimedwait(parent_sigset_ptr, &sig, &ts) == -1) {
+		switch (errno) {
+			case EAGAIN:
+				break;
+			case EINTR:
+				break;
+			default:
+				PRINT_FATAL("Unexpected error in sigtimedwait: '%s'", strerror(errno));
+				return 1;
+		}
+	} else {
+		/* There is a signal to handle here */
+		switch (sig.si_signo) {
+			case SIGCHLD:
+				/* Special-cased, as we don't forward SIGCHLD. Instead, we'll
+				 * fallthrough to reaping processes.
+				 */
+				PRINT_DEBUG("Received SIGCHLD");
+				break;
+			default:
+				PRINT_DEBUG("Passing signal: '%s'", strsignal(sig.si_signo));
+				/* Forward anything else */
+				if (kill(kill_process_group ? -child_pid : child_pid, sig.si_signo)) {
+					if (errno == ESRCH) {
+						PRINT_WARNING("Child was dead when forwarding signal");
+					} else {
+						PRINT_FATAL("Unexpected error when forwarding signal: '%s'", strerror(errno));
+						return 1;
+					}
+				}
+				break;
+		}
+	}
+
+	return 0;
+}
+
+int reap_zombies(const pid_t child_pid, int* const child_exitcode_ptr) {
+	pid_t current_pid;
+	int current_status;
+
+	while (1) {
+		current_pid = waitpid(-1, &current_status, WNOHANG);
+
+		switch (current_pid) {
+
+			case -1:
+				if (errno == ECHILD) {
+					PRINT_TRACE("No child to wait");
+					break;
+				}
+				PRINT_FATAL("Error while waiting for pids: '%s'", strerror(errno));
+				return 1;
+
+			case 0:
+				PRINT_TRACE("No child to reap");
+				break;
+
+			default:
+				/* A child was reaped. Check whether it's the main one. If it is, then
+				 * set the exit_code, which will cause us to exit once we've reaped everyone else.
+				 */
+				PRINT_DEBUG("Reaped child with pid: '%i'", current_pid);
+				if (current_pid == child_pid) {
+					if (WIFEXITED(current_status)) {
+						/* Our process exited normally. */
+						PRINT_INFO("Main child exited normally (with status '%i')", WEXITSTATUS(current_status));
+						*child_exitcode_ptr = WEXITSTATUS(current_status);
+					} else if (WIFSIGNALED(current_status)) {
+						/* Our process was terminated. Emulate what sh / bash
+						 * would do, which is to return 128 + signal number.
+						 */
+						PRINT_INFO("Main child exited with signal (with signal '%s')", strsignal(WTERMSIG(current_status)));
+						*child_exitcode_ptr = 128 + WTERMSIG(current_status);
+					} else {
+						PRINT_FATAL("Main child exited for unknown reason");
+						return 1;
+					}
+
+					// Be safe, ensure the status code is indeed between 0 and 255.
+					*child_exitcode_ptr = *child_exitcode_ptr % (STATUS_MAX - STATUS_MIN + 1);
+
+					// If this exitcode was remapped, then set it to 0.
+					INT32_BITFIELD_CHECK_BOUNDS(expect_status, *child_exitcode_ptr);
+					if (INT32_BITFIELD_TEST(expect_status, *child_exitcode_ptr)) {
+						*child_exitcode_ptr = 0;
+					}
+				} else if (warn_on_reap > 0) {
+					PRINT_WARNING("Reaped zombie process with pid=%i", current_pid);
+				}
+
+				// Check if other childs have been reaped.
+				continue;
+		}
+
+		/* If we make it here, that's because we did not continue in the switch case. */
+		break;
+	}
+
+	return 0;
+}
+
+
+int main(int argc, char *argv[]) {
+	pid_t child_pid;
+
+	// Those are passed to functions to get an exitcode back.
+	int child_exitcode = -1;  // This isn't a valid exitcode, and lets us tell whether the child has exited.
+	int parse_exitcode = 1;   // By default, we exit with 1 if parsing fails.
+
+	/* Parse command line arguments */
+	char* (*child_args_ptr)[];
+	int parse_args_ret = parse_args(argc, argv, &child_args_ptr, &parse_exitcode);
+	if (parse_args_ret) {
+		return parse_exitcode;
+	}
+
+	/* Parse environment */
+	if (parse_env()) {
+		return 1;
+	}
+
+	/* Configure signals */
+	sigset_t parent_sigset, child_sigset;
+	struct sigaction sigttin_action, sigttou_action;
+	memset(&sigttin_action, 0, sizeof sigttin_action);
+	memset(&sigttou_action, 0, sizeof sigttou_action);
+
+	signal_configuration_t child_sigconf = {
+		.sigmask_ptr = &child_sigset,
+		.sigttin_action_ptr = &sigttin_action,
+		.sigttou_action_ptr = &sigttou_action,
+	};
+
+	if (configure_signals(&parent_sigset, &child_sigconf)) {
+		return 1;
+	}
+
+	/* Trigger signal on this process when the parent process exits. */
+	if (parent_death_signal && prctl(PR_SET_PDEATHSIG, parent_death_signal)) {
+		PRINT_FATAL("Failed to set up parent death signal");
+		return 1;
+	 }
+
+#if HAS_SUBREAPER
+	/* If available and requested, register as a subreaper */
+	if (register_subreaper()) {
+		return 1;
+	};
+#endif
+
+	/* Are we going to reap zombies properly? If not, warn. */
+	reaper_check();
+
+	/* Go on */
+	int spawn_ret = spawn(&child_sigconf, *child_args_ptr, &child_pid);
+	if (spawn_ret) {
+		return spawn_ret;
+	}
+	free(child_args_ptr);
+
+	while (1) {
+		/* Wait for one signal, and forward it */
+		if (wait_and_forward_signal(&parent_sigset, child_pid)) {
+			return 1;
+		}
+
+		/* Now, reap zombies */
+		if (reap_zombies(child_pid, &child_exitcode)) {
+			return 1;
+		}
+
+		if (child_exitcode != -1) {
+			PRINT_TRACE("Exiting: child has exited");
+			return child_exitcode;
+		}
+	}
+}


### PR DESCRIPTION
* Adds support for C bug generation
* Needs to pin to older tree-sitter-c for compatibility with released tree-sitter version
* tree-sitter-c creates error nodes for many preprocessor directives. I've avoided emitting warnings as a result but this may hide legitimate parsing errors.