### PR TITLE
Various Fixes

### DIFF
--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -17,7 +17,6 @@ python -m swesmith.bug_gen.collect_patches logs/bug_gen/pandas-dev__pandas.95280
 
 # Run validation on the collected task instances
 python -m swesmith.harness.valid logs/bug_gen/pandas-dev__pandas.95280573_all_patches.json \
-  --run_id pandas_test \
   --max_workers=8
 
 # Gather valid task instances

--- a/docs/guides/harnesses.md
+++ b/docs/guides/harnesses.md
@@ -25,9 +25,7 @@ This produces a `logs/bug_gen/<repo>_all_patches.json` file with all the candida
 2. Run validation
 
 ```bash
-python -m swesmith.harness.valid \
-    logs/bug_gen/<repo>_all_patches.json \
-    --run_id <run_id>
+python -m swesmith.harness.valid logs/bug_gen/<repo>_all_patches.json
 ```
 
 The validation harness works in two steps.

--- a/scripts/cheatsheet.sh
+++ b/scripts/cheatsheet.sh
@@ -71,8 +71,7 @@ python -m swesmith.bug_gen.mirror.generate path/to/task_candidates.jsonl --model
 python -m swesmith.bug_gen.collect_patches logs/bug_gen/$repo
 
 # Run validation
-python -m swesmith.harness.valid logs/bug_gen/$repo_all_patches.json \
-    --run_id $repo
+python -m swesmith.harness.valid logs/bug_gen/$repo_all_patches.json
 
 # Collect task instances with 1+ F2P
 python -m swesmith.harness.gather logs/run_validation/$repo

--- a/swesmith/bug_gen/adapters/__init__.py
+++ b/swesmith/bug_gen/adapters/__init__.py
@@ -17,3 +17,5 @@ get_entities_from_file = {
     "rb": get_entities_from_file_rb,
     "rs": get_entities_from_file_rs,
 }
+
+SUPPORTED_EXTS = list(get_entities_from_file.keys())

--- a/swesmith/bug_gen/llm/modify.py
+++ b/swesmith/bug_gen/llm/modify.py
@@ -118,6 +118,7 @@ def main(
     n_bugs: int,
     repo: str,
     n_workers: int = 1,
+    max_bugs: int = -1,
     **kwargs,
 ):
     # Check arguments
@@ -138,6 +139,15 @@ def main(
     if not candidates:
         print(f"No candidates found in {repo}.")
         return
+
+    # Adjust candidates if max_bugs is specified
+    if max_bugs > 0:
+        max_candidates = max_bugs // n_bugs
+        if max_candidates < len(candidates):
+            candidates = candidates[:max_candidates]
+            print(f"Limited to {len(candidates)} candidates to generate ~{len(candidates) * n_bugs} bugs (max: {max_bugs})")
+        else:
+            print(f"Will generate {len(candidates) * n_bugs} bugs (max: {max_bugs})")
 
     print(f"Generating bugs in {repo} using {model}...")
     if not kwargs.get("yes", False):
@@ -214,6 +224,7 @@ if __name__ == "__main__":
         help="Name of a SWE-smith repository to generate bugs for.",
     )
     parser.add_argument(
+        "-c",
         "--config_file",
         type=str,
         help="Configuration file containing bug gen. strategy prompts",
@@ -226,13 +237,21 @@ if __name__ == "__main__":
         default="openai/gpt-4o",
     )
     parser.add_argument(
+        "-n",
         "--n_bugs",
         type=int,
         help="Number of bugs to generate per entity",
         default=1,
     )
     parser.add_argument(
-        "--n_workers", type=int, help="Number of workers to use", default=1
+        "-m",
+        "--max_bugs",
+        type=int,
+        help="Total, maximum number of bugs to generate",
+        default=-1
+    )
+    parser.add_argument(
+        "-w", "--n_workers", type=int, help="Number of workers to use", default=1
     )
     parser.add_argument("-y", "--yes", action="store_true", help="Skip confirmation")
     args = parser.parse_args()

--- a/swesmith/bug_gen/llm/rewrite.py
+++ b/swesmith/bug_gen/llm/rewrite.py
@@ -119,7 +119,10 @@ def main(
             if k in configs
         ]
         messages = [x for x in messages if x["content"]]
-        response: Any = completion(model=model, messages=messages, n=1, temperature=0)
+        try:
+            response: Any = completion(model=model, messages=messages, n=1, temperature=0)
+        except litellm.ContextWindowExceededError:
+            return {"n_generation_failed": 1, "cost": 0.0}
         choice = response.choices[0]
         message = choice.message
 
@@ -144,6 +147,8 @@ def main(
         )
         apply_code_change(candidate, rewrite)
         patch = get_patch(repo, reset_changes=True)
+        if not patch or len(patch.strip()) == 0:
+            return {"n_generation_failed": 0, "cost": cost}
 
         # Log the bug
         bug_dir.mkdir(parents=True, exist_ok=True)
@@ -185,17 +190,17 @@ if __name__ == "__main__":
         "repo", type=str, help="Repository to generate bug patches for."
     )
     parser.add_argument(
-        "--config_file", type=str, help="Path to the configuration file.", required=True
+        "-c", "--config_file", type=str, help="Path to the configuration file.", required=True
     )
     parser.add_argument("--model", type=str, help="Model to use for rewriting.")
     parser.add_argument(
-        "--n_workers", type=int, help="Number of workers to use", default=1
+        "-w", "--n_workers", type=int, help="Number of workers to use", default=1
     )
     parser.add_argument(
         "--redo_existing", action="store_true", help="Redo existing bugs."
     )
     parser.add_argument(
-        "--max_bugs", type=int, help="Maximum number of bugs to generate."
+        "-m", "--max_bugs", type=int, help="Maximum number of bugs to generate."
     )
     args = parser.parse_args()
     main(**vars(args))

--- a/swesmith/harness/eval.py
+++ b/swesmith/harness/eval.py
@@ -78,9 +78,9 @@ def run_evaluation(
 
 
 def main(
-    predictions_path: str,
     run_id: str,
     max_workers: int,
+    predictions_path: str = "gold",
     dataset_path: str = HF_DATASET,
     instance_ids: list | None = None,
     report_only: bool = False,
@@ -212,7 +212,7 @@ if __name__ == "__main__":
         "-d", "--dataset_path", type=str, help="Path to dataset", default=HF_DATASET
     )
     parser.add_argument(
-        "-p", "--predictions_path", type=str, help="Path to predictions"
+        "-p", "--predictions_path", type=str, help="Path to predictions", default="gold"
     )
     parser.add_argument("--run_id", type=str, help="Unique identifier for this run")
     parser.add_argument(

--- a/swesmith/harness/eval.py
+++ b/swesmith/harness/eval.py
@@ -209,9 +209,9 @@ def main(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser("Evaluate predications on SWEFT bugs")
     parser.add_argument(
-        "--dataset_path", type=str, help="Path to dataset", default=HF_DATASET
+        "-d", "--dataset_path", type=str, help="Path to dataset", default=HF_DATASET
     )
-    parser.add_argument("--predictions_path", type=str, help="Path to predictions")
+    parser.add_argument("-p", "--predictions_path", type=str, help="Path to predictions")
     parser.add_argument("--run_id", type=str, help="Unique identifier for this run")
     parser.add_argument(
         "--max_workers", type=int, help="Number of workers to use", default=4

--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -246,19 +246,20 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
 
         return self._test_paths_cache[cache_key]
 
-    def get_test_cmd(self, instance: dict):
+    def get_test_cmd(self, instance: dict) -> tuple[str, list[Path]]:
         assert instance[KEY_INSTANCE_ID].rsplit(".", 1)[0] == self.repo_name, (
             f"WARNING: {instance[KEY_INSTANCE_ID]} not from {self.repo_name}"
         )
         test_command = self.test_cmd
 
-        if FAIL_TO_PASS in instance and "pytest" in test_command:
+        if FAIL_TO_PASS in instance:
             # NOTE: Using F2P key as indicator that this is eval instance, not validation
-            f2p_files = sorted(
-                list(set([x.split("::", 1)[0] for x in instance[FAIL_TO_PASS]]))
-            )
-            test_command += f" {' '.join(f2p_files)}"
-            return test_command, f2p_files
+            if "pytest" in test_command:
+                f2p_files = sorted(
+                    list(set([x.split("::", 1)[0] for x in instance[FAIL_TO_PASS]]))
+                )
+                test_command += f" {' '.join(f2p_files)}"
+                return test_command, f2p_files
 
         if not self.min_testing or KEY_PATCH not in instance:
             # If min testing is not enabled or there's no patch
@@ -281,62 +282,49 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
                     if str(test_path).endswith(x.path) or str(test_path).endswith(
                         Path(x.path).name
                     ):
-                        rv.append(str(test_path))
+                        rv.append(test_path)
             if len(rv) > 0:
-                test_command += f" {' '.join(rv)}"
+                test_command += f" {' '.join([str(v) for v in rv])}"
                 return test_command, rv
 
         # Identify relevant test files based on the patch
         patch_paths = [Path(f.path) for f in PatchSet(instance[KEY_PATCH])]
         rv = []
-        for patch_path in patch_paths:
-            file_name = patch_path.name.strip(".py")
-            parent_dir = patch_path.parent.name
+        for pp in patch_paths:
             for test_path in test_paths:
                 # Check for common test file naming conventions first
                 # If found, add to list and break
                 common_test_names = [
-                    f"test_{file_name}.py",
-                    f"test{file_name}.py",
-                    f"{file_name}_test.py",
-                    f"{file_name}test.py",
+                    f"test_{pp.stem}{pp.suffix}",
+                    f"test{pp.stem}{pp.suffix}",
+                    f"{pp.stem}_test{pp.suffix}",
+                    f"{pp.stem}test{pp.suffix}",
                 ]
-                if any(
-                    [
-                        str(test_path).endswith(f"{parent_dir}/{name}")
-                        or str(test_path).endswith(name)
-                        for name in common_test_names
-                    ]
-                ):
-                    rv.append(str(test_path))
+                if any([
+                    str(test_path).endswith(name)
+                    for name in common_test_names
+                ]):
+                    rv.append(test_path)
                     break
             else:
                 for test_path in test_paths:
-                    if parent_dir == test_path.parent.name:
+                    if pp.parent.name == test_path.parent.name:
                         # If similar testing folder found, add to list and break
-                        rv.append(str(test_path.parent))
+                        rv.append(test_path.parent)
                         break
                     elif any(
-                        [
-                            x.format(parent_dir) == test_path.name
-                            for x in [
-                                "test_{}.py",
-                                "test{}.py",
-                                "{}_test.py",
-                                "{}test.py",
-                            ]
-                        ]
+                        [test_path.stem in {f"test_{pp.parent.name}", f"test{pp.parent.name}", f"{pp.parent.name}_test", f"{pp.parent.name}test"}]
                     ):
-                        rv.append(str(test_path))
+                        rv.append(test_path)
 
         if len(rv) > 0:
             # Remove duplicates
-            test_files = [x for x in rv if x.endswith(".py")]
-            final = [x for x in rv if not x.endswith(".py")]
+            test_files = [x for x in rv if x.is_file()]
+            final = [x for x in rv if not x.is_file()]
             for test_file in test_files:
                 if os.path.dirname(test_file) not in final:
                     final.append(test_file)
-            test_command += f" {' '.join(set(final))}"
+            test_command += f" {' '.join(sorted([str(v) for v in set((final))]))}"
 
         return test_command, rv
 

--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -17,7 +17,7 @@ from dotenv import load_dotenv
 from ghapi.all import GhApi
 from multiprocessing import Lock
 from pathlib import Path
-from swesmith.bug_gen.adapters import get_entities_from_file
+from swesmith.bug_gen.adapters import get_entities_from_file, SUPPORTED_EXTS
 from swebench.harness.constants import FAIL_TO_PASS, KEY_INSTANCE_ID
 from swesmith.constants import (
     KEY_PATCH,
@@ -65,7 +65,7 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
     # Install + Test specifications
     test_cmd: str = ""
     test_exts: list[str] = field(
-        default_factory=lambda: [".py", ".go", ".rb", ".php", ".java"]
+        default_factory=lambda: SUPPORTED_EXTS
     )
 
     # `min_testing`: If set, then subset of tests (not all) are run for post-bug validation

--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -64,7 +64,7 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
 
     # Install + Test specifications
     test_cmd: str = ""
-    test_exts: list[str] = field(default_factory=lambda: SUPPORTED_EXTS)
+    test_exts: list[str] = field(default_factory=lambda: [f".{ext}" for ext in SUPPORTED_EXTS])
 
     # `min_testing`: If set, then subset of tests (not all) are run for post-bug validation
     # Affects get_test_cmd, get_valid_report

--- a/swesmith/profiles/golang.py
+++ b/swesmith/profiles/golang.py
@@ -40,6 +40,7 @@ RUN go mod tidy
                 if match:
                     test_name = match.group(1)
                     test_status_map[test_name] = status
+                    break
 
         return test_status_map
 

--- a/swesmith/profiles/golang.py
+++ b/swesmith/profiles/golang.py
@@ -149,6 +149,11 @@ class Natsserver2ee2e24c(GoProfile):
     commit: str = "2ee2e24cb10924adb699ecb68b89e8ce2523ea75"
 
 
+@dataclass
+class Addressec203a4f(GoProfile):
+    owner: str = "bojanz"
+    repo: str = "address"
+    commit: str = "ec203a4f7f569c03a0f83e2e749b63947481fe4c"
 
 
 @dataclass
@@ -170,6 +175,20 @@ class Gozero75cebb65(GoProfile):
     owner: str = "zeromicro"
     repo: str = "go-zero"
     commit: str = "75cebb65f88cc6019d9e16e34c4a567e621f4dd5"
+
+
+@dataclass
+class Goatcounter854b1dd2(GoProfile):
+    owner: str = "arp242"
+    repo: str = "goatcounter"
+    commit: str = "854b1dd2408ca95645ad03ea3fd01ccfe267261a"
+
+
+@dataclass
+class Gotests16a93f6e(GoProfile):
+    owner: str = "cweill"
+    repo: str = "gotests"
+    commit: str = "16a93f6eb6519118b1d282e2f233596a98dd7e96"
 
 
 # Register all Go profiles with the global registry

--- a/swesmith/profiles/golang.py
+++ b/swesmith/profiles/golang.py
@@ -14,25 +14,32 @@ class GoProfile(RepoProfile):
     repository profiles.
     """
 
-    test_cmd: str = "go test -v ./..."
+    test_cmd: str = "go test -v -count=1 ./..."
+
+    @property
+    def dockerfile(self):
+        return f"""FROM golang:1.24
+RUN git clone https://github.com/{self.mirror_name} /testbed
+WORKDIR /testbed
+RUN go mod tidy
+"""
 
     def log_parser(self, log: str) -> dict[str, str]:
         """Parser for test logs generated with 'go test'"""
         test_status_map = {}
 
-        # Pattern to match test result lines
-        pattern = r"^--- (PASS|FAIL|SKIP): (.+) \((.+)\)$"
-
+        pattern_status_map = [
+            (re.compile(r"--- PASS: (\S+)"), TestStatus.PASSED.value),
+            (re.compile(r"--- FAIL: (\S+)"), TestStatus.FAILED.value),
+            (re.compile(r"FAIL:?\s?(.+?)\s"), TestStatus.FAILED.value),
+            (re.compile(r"--- SKIP: (\S+)"), TestStatus.SKIPPED.value),
+        ]
         for line in log.split("\n"):
-            match = re.match(pattern, line.strip())
-            if match:
-                status, test_name, _ = match.groups()
-                if status == "PASS":
-                    test_status_map[test_name] = TestStatus.PASSED.value
-                elif status == "FAIL":
-                    test_status_map[test_name] = TestStatus.FAILED.value
-                elif status == "SKIP":
-                    test_status_map[test_name] = TestStatus.SKIPPED.value
+            for pattern, status in pattern_status_map:
+                match = pattern.match(line.strip())
+                if match:
+                    test_name = match.group(1)
+                    test_status_map[test_name] = status
 
         return test_status_map
 
@@ -42,15 +49,127 @@ class Gin3c12d2a8(GoProfile):
     owner: str = "gin-gonic"
     repo: str = "gin"
     commit: str = "3c12d2a80e40930632fc4a4a4e1a45140f33fb12"
+    
 
-    @property
-    def dockerfile(self):
-        return f"""FROM golang:1.24
-RUN git clone https://github.com/{self.mirror_name} /testbed
-WORKDIR /testbed
-RUN go mod tidy
-RUN go test ./...
-"""
+@dataclass
+class Fzf976001e4(GoProfile):
+    owner: str = "junegunn"
+    repo: str = "fzf"
+    commit: str = "976001e47459973b5e72565f3047cc9d9e20241d"
+    
+
+@dataclass
+class Beego8fd113aa(GoProfile):
+    owner: str = "beego"
+    repo: str = "beego"
+    commit: str = "8fd113aa0937a11c45eb41cbf147f33df7e9fb6f"
+
+
+@dataclass
+class Caddy77dd12cc(GoProfile):
+    owner: str = "caddyserver"
+    repo: str = "caddy"
+    commit: str = "77dd12cc785990c5c5da947b4e883029ab8bd552"
+
+
+@dataclass
+class Cli4c47bad6(GoProfile):
+    owner: str = "cli"
+    repo: str = "cli"
+    commit: str = "4c47bad604d8b206a4bc686507b2e9a3bed2b317"
+
+
+@dataclass
+class Concourse24abde66(GoProfile):
+    owner: str = "concourse"
+    repo: str = "concourse"
+    commit: str = "24abde66ec91853eebdcf273a064e31accae9f25"
+
+
+@dataclass
+class Etcd721ba5bc(GoProfile):
+    owner: str = "etcd-io"
+    repo: str = "etcd"
+    commit: str = "721ba5bc2489e0588b224a099a0fa369f166b4e5"
+
+
+@dataclass
+class Frp61330d4d(GoProfile):
+    owner: str = "fatedier"
+    repo: str = "frp"
+    commit: str = "61330d4d794180c38d1f8ff7e9024b7f0f69d717"
+
+
+@dataclass
+class Gorm1e8baf54(GoProfile):
+    owner: str = "go-gorm"
+    repo: str = "gorm"
+    commit: str = "1e8baf545953dd58e2f301f4dfef5febbc12da0f"
+
+
+@dataclass
+class Hugocfc8d315(GoProfile):
+    owner: str = "gohugoio"
+    repo: str = "hugo"
+    commit: str = "cfc8d315b4f1a21c3daed0f9e78b7edb19f298d1"
+
+
+@dataclass
+class Grpcaa57e6af(GoProfile):
+    owner: str = "grpc"
+    repo: str = "grpc-go"
+    commit: str = "aa57e6af6cbc8e1285315b338b092420f014c732"
+
+
+@dataclass
+class Istio8c687844(GoProfile):
+    owner: str = "istio"
+    repo: str = "istio"
+    commit: str = "8c687844a88bfc4a7d4f998e4c950cd9243334c3"
+
+
+@dataclass
+class Lazygit91d8c251(GoProfile):
+    owner: str = "jesseduffield"
+    repo: str = "lazygit"
+    commit: str = "91d8c25183fde8e0d9ae51b8a24acb545b9cb278"
+
+
+@dataclass
+class Echo98ca08e7(GoProfile):
+    owner: str = "labstack"
+    repo: str = "echo"
+    commit: str = "98ca08e7dd64075b858e758d6693bf9799340756"
+
+
+@dataclass
+class Natsserver2ee2e24c(GoProfile):
+    owner: str = "nats-io"
+    repo: str = "nats-server"
+    commit: str = "2ee2e24cb10924adb699ecb68b89e8ce2523ea75"
+
+
+
+
+@dataclass
+class Prometheus74aca682(GoProfile):
+    owner: str = "prometheus"
+    repo: str = "prometheus"
+    commit: str = "74aca682b77d66f5761bd68459f3b570ec34ce2d"
+
+
+@dataclass
+class Syncthing06dd8ee(GoProfile):
+    owner: str = "syncthing"
+    repo: str = "syncthing"
+    commit: str = "06dd8ee6d75e14a62b7da28b2eec33f2f5695fc8"
+
+
+@dataclass
+class Gozero75cebb65(GoProfile):
+    owner: str = "zeromicro"
+    repo: str = "go-zero"
+    commit: str = "75cebb65f88cc6019d9e16e34c4a567e621f4dd5"
 
 
 # Register all Go profiles with the global registry

--- a/swesmith/profiles/python.py
+++ b/swesmith/profiles/python.py
@@ -25,7 +25,11 @@ class PythonProfile(RepoProfile):
     install_cmds: list[str] = field(
         default_factory=lambda: ["python -m pip install -e ."]
     )
-    test_cmd: str = "pytest --disable-warnings --color=no --tb=no --verbose"
+    test_cmd: str = (
+        "source /opt/miniconda3/bin/activate; "
+        f"conda activate {ENV_NAME}; "
+        "pytest --disable-warnings --color=no --tb=no --verbose"
+    )
     test_exts: list[str] = field(default_factory=lambda: [".py"])
 
     def build_image(self):
@@ -384,7 +388,11 @@ class Gpxpy09fc46b3(PythonProfile):
     owner: str = "tkrajina"
     repo: str = "gpxpy"
     commit: str = "09fc46b3cad16b5bf49edf8e7ae873794a959620"
-    test_cmd: str = "pytest test.py --verbose --color=no --tb=no --disable-warnings"
+    test_cmd: str = (
+        "source /opt/miniconda3/bin/activate; "
+        f"conda activate {ENV_NAME}; "
+        "pytest test.py --verbose --color=no --tb=no --disable-warnings"
+    )
 
 
 @dataclass
@@ -463,7 +471,11 @@ class JaxEbd90e06f(PythonProfile):
     repo: str = "jax"
     commit: str = "ebd90e06fa7caad087e2342431e3899cfd2fdf98"
     install_cmds: list = field(default_factory=lambda: ['pip install -e ".[cpu]"'])
-    test_cmd: str = "pytest --disable-warnings --color=no --tb=no --verbose -n auto"
+    test_cmd: str = (
+        "source /opt/miniconda3/bin/activate; "
+        f"conda activate {ENV_NAME}; "
+        "pytest --disable-warnings --color=no --tb=no --verbose -n auto"
+    )
     min_testing: bool = True
     min_pregold: bool = True
 
@@ -522,7 +534,11 @@ class MidoA0158ff9(PythonProfile):
     owner: str = "mido"
     repo: str = "mido"
     commit: str = "a0158ff95a08f9a4eef628a2e7c793fd3a466640"
-    test_cmd = "pytest --disable-warnings --color=no --tb=no --verbose -rs -c /dev/null"
+    test_cmd: str = (
+        "source /opt/miniconda3/bin/activate; "
+        f"conda activate {ENV_NAME}; "
+        "pytest --disable-warnings --color=no --tb=no --verbose -rs -c /dev/null"
+    )
 
 
 @dataclass
@@ -554,7 +570,11 @@ class Paramiko23f92003(PythonProfile):
     owner: str = "paramiko"
     repo: str = "paramiko"
     commit: str = "23f92003898b060df0e2b8b1d889455264e63a3e"
-    test_cmd = "pytest -rA --color=no --disable-warnings"
+    test_cmd: str = (
+        "source /opt/miniconda3/bin/activate; "
+        f"conda activate {ENV_NAME}; "
+        "pytest -rA --color=no --disable-warnings"
+    )
 
     def log_parser(self, log: str) -> dict[str, str]:
         test_status_map = {}
@@ -755,7 +775,11 @@ class PythonSlugify872b3750(PythonProfile):
     owner: str = "un33k"
     repo: str = "python-slugify"
     commit: str = "872b37509399a7f02e53f46ad9881f63f66d334b"
-    test_cmd = "python test.py --verbose"
+    test_cmd: str = (
+        "source /opt/miniconda3/bin/activate; "
+        f"conda activate {ENV_NAME}; "
+        "python test.py --verbose"
+    )
 
     def log_parser(self, log: str) -> dict[str, str]:
         test_status_map = {}
@@ -978,7 +1002,11 @@ class TornadoD5ac65c1(PythonProfile):
     owner: str = "tornadoweb"
     repo: str = "tornado"
     commit: str = "d5ac65c1f1453c2aeddd089d8e68c159645c13e1"
-    test_cmd = "python -m tornado.test --verbose"
+    test_cmd: str = (
+        "source /opt/miniconda3/bin/activate; "
+        f"conda activate {ENV_NAME}; "
+        "python -m tornado.test --verbose"
+    )
 
     def log_parser(self, log: str) -> dict[str, str]:
         test_status_map = {}
@@ -1087,7 +1115,11 @@ class MypyE93f06ce(PythonProfile):
             "hash -r",
         ]
     )
-    test_cmd = "pytest --color=no -rA -k"
+    test_cmd: str = (
+        "source /opt/miniconda3/bin/activate; "
+        f"conda activate {ENV_NAME}; "
+        "pytest --color=no -rA -k"
+    )
     min_testing: bool = True
 
     def get_test_cmd(self, instance: str) -> tuple[str, list]:
@@ -1129,7 +1161,11 @@ class MONAIa09c1f08(PythonProfile):
             "python -m pip install -e .",
         ]
     )
-    test_cmd = "pytest --disable-warnings --color=no --tb=no --verbose"
+    test_cmd: str = (
+        "source /opt/miniconda3/bin/activate; "
+        f"conda activate {ENV_NAME}; "
+        "pytest --disable-warnings --color=no --tb=no --verbose"
+    )
     min_pregold: bool = True
     min_testing: bool = True
 
@@ -1195,7 +1231,7 @@ class PydanticAcb0f10f(PythonProfile):
             "make install",
         ]
     )
-    test_cmd = (
+    test_cmd: str = (
         "/root/.local/bin/uv run pytest --disable-warnings --color=no --tb=no --verbose"
     )
 

--- a/tests/profiles/test_base.py
+++ b/tests/profiles/test_base.py
@@ -481,8 +481,8 @@ def test_get_test_cmd_eval_mode():
     # Order of files may vary, so check set equality
     parts = test_command.split()
     assert parts[0] == "pytest"
+    assert set([str(f) for f in test_files]) == {"test_file.py", "other_file.py"}
     assert set(parts[1:]) == {"test_file.py", "other_file.py"}
-    assert set(test_files) == {"test_file.py", "other_file.py"}
 
 
 def test_get_test_cmd_min_testing():

--- a/tests/profiles/test_profiles_golang.py
+++ b/tests/profiles/test_profiles_golang.py
@@ -62,7 +62,7 @@ def test_go_profile_log_parser_edge_cases():
 --- SKIP: TestBaz (0.00s)
 """
     result = profile.log_parser(log)
-    assert "TestBar" not in result
+    assert "TestBar" in result
     assert "TestBaz" in result
 
 
@@ -148,7 +148,7 @@ def test_go_profile_build_image_subprocess_parameters():
 
 def test_go_profile_go_test_command():
     profile = make_dummy_go_profile()
-    assert profile.test_cmd == "go test -v ./..."
+    assert profile.test_cmd == "go test -v -count=1 ./..."
     assert "go test" in profile.test_cmd
     assert "-v" in profile.test_cmd
     assert "./..." in profile.test_cmd
@@ -162,4 +162,3 @@ def test_gin_profile_dockerfile_content():
     assert f"git clone https://github.com/{profile.mirror_name}" in dockerfile
     assert "WORKDIR /testbed" in dockerfile
     assert "go mod tidy" in dockerfile
-    assert "go test ./..." in dockerfile

--- a/tests/profiles/test_profiles_python.py
+++ b/tests/profiles/test_profiles_python.py
@@ -14,7 +14,11 @@ def test_python_profile_defaults():
 
     assert profile.python_version == "3.10"
     assert profile.install_cmds == ["python -m pip install -e ."]
-    assert profile.test_cmd == "pytest --disable-warnings --color=no --tb=no --verbose"
+    assert profile.test_cmd == (
+        "source /opt/miniconda3/bin/activate; "
+        f"conda activate testbed; "
+        "pytest --disable-warnings --color=no --tb=no --verbose"
+    )
 
 
 def test_python_profile_build_image():
@@ -138,8 +142,11 @@ def test_python_profile_custom_test_cmd():
     from swesmith.profiles.python import Gpxpy09fc46b3
 
     profile = Gpxpy09fc46b3()
-    expected_cmd = "pytest test.py --verbose --color=no --tb=no --disable-warnings"
-    assert profile.test_cmd == expected_cmd
+    assert profile.test_cmd == (
+        "source /opt/miniconda3/bin/activate; "
+        f"conda activate testbed; "
+        "pytest test.py --verbose --color=no --tb=no --disable-warnings"
+    )
     assert profile.test_cmd != PythonProfile().test_cmd
 
 

--- a/tests/profiles/test_profiles_python.py
+++ b/tests/profiles/test_profiles_python.py
@@ -1,4 +1,5 @@
 import pytest
+from swesmith.constants import ENV_NAME
 from unittest.mock import patch, MagicMock, mock_open
 from pathlib import Path
 
@@ -16,7 +17,7 @@ def test_python_profile_defaults():
     assert profile.install_cmds == ["python -m pip install -e ."]
     assert profile.test_cmd == (
         "source /opt/miniconda3/bin/activate; "
-        f"conda activate testbed; "
+        f"conda activate {ENV_NAME}; "
         "pytest --disable-warnings --color=no --tb=no --verbose"
     )
 
@@ -144,7 +145,7 @@ def test_python_profile_custom_test_cmd():
     profile = Gpxpy09fc46b3()
     assert profile.test_cmd == (
         "source /opt/miniconda3/bin/activate; "
-        f"conda activate testbed; "
+        f"conda activate {ENV_NAME}; "
         "pytest test.py --verbose --color=no --tb=no --disable-warnings"
     )
     assert profile.test_cmd != PythonProfile().test_cmd


### PR DESCRIPTION
This PR introduces a couple fixes to SWE-smith, including
* Getting rid of `run_id` from `valid.py`. We just use `instance['repo']` by default now, as this convention is also assumed downstream by the bug generation pipeline.
* Add a `max_bugs` argument to the LM modify bug generation method, currently it is limitless
* Error handling for LM rewrite, specifically (1) when the input context is too long, and (2) if the LM rewrites the function perfectly (so the patch is empty)
* Add shorthands for arguments.
* Clean up `get_test_cmd` to be Python agnostic