### PR TITLE
Chore: Tiny typing fix

### DIFF
--- a/swesmith/bug_gen/llm/rewrite.py
+++ b/swesmith/bug_gen/llm/rewrite.py
@@ -60,7 +60,7 @@ def main(
     model: str,
     n_workers: int,
     redo_existing: bool = False,
-    max_bugs: int = None,
+    max_bugs: int | None = None,
     **kwargs,
 ):
     configs = yaml.safe_load(open(config_file))


### PR DESCRIPTION
Only of relevance because this is the first fix produced by micro-swe-agent with the following prompt:

```
 There's a lot of instances where this code does var: Type = None, 
but it's missing to do Type|None = None, so type checkers flag it. 
Find all instances by querying for `=None` or ` = None`, then check & fix them. Don't get distracted by anything else.
```

solved with $0.05 and Sonnet 4