### PR TITLE
Fix #24: Fix eval script to look for explicit passes

### DIFF
--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -16,8 +16,7 @@ python -m swesmith.bug_gen.llm.modify pandas-dev__pandas.95280573 \
 python -m swesmith.bug_gen.collect_patches logs/bug_gen/pandas-dev__pandas.95280573/
 
 # Run validation on the collected task instances
-python -m swesmith.harness.valid logs/bug_gen/pandas-dev__pandas.95280573_all_patches.json \
-  --max_workers=8
+python -m swesmith.harness.valid logs/bug_gen/pandas-dev__pandas.95280573_all_patches.json --workers 8
 
 # Gather valid task instances
 python -m swesmith.harness.gather logs/run_validation/pandas_test

--- a/docs/guides/train_swe_agent.md
+++ b/docs/guides/train_swe_agent.md
@@ -66,7 +66,7 @@ python -m swesmith.harness.eval \
     --dataset_path path/to/subset0.json \
     --predictions_path path/to/trajectories/<username>/<run ID>/preds.json \
     --run_id <run ID> \
-    --max_workers 10 \
+    --workers 10 \
     --timeout 240
 ```
 

--- a/swesmith/bug_gen/adapters/__init__.py
+++ b/swesmith/bug_gen/adapters/__init__.py
@@ -8,14 +8,14 @@ from swesmith.bug_gen.adapters.ruby import get_entities_from_file_rb
 from swesmith.bug_gen.adapters.rust import get_entities_from_file_rs
 
 get_entities_from_file = {
-    "c": get_entities_from_file_c,
-    "go": get_entities_from_file_go,
-    "java": get_entities_from_file_java,
-    "js": get_entities_from_file_js,
-    "php": get_entities_from_file_php,
-    "py": get_entities_from_file_py,
-    "rb": get_entities_from_file_rb,
-    "rs": get_entities_from_file_rs,
+    ".c": get_entities_from_file_c,
+    ".go": get_entities_from_file_go,
+    ".java": get_entities_from_file_java,
+    ".js": get_entities_from_file_js,
+    ".php": get_entities_from_file_php,
+    ".py": get_entities_from_file_py,
+    ".rb": get_entities_from_file_rb,
+    ".rs": get_entities_from_file_rs,
 }
 
 SUPPORTED_EXTS = list(get_entities_from_file.keys())

--- a/swesmith/build_repo/create_images.py
+++ b/swesmith/build_repo/create_images.py
@@ -33,12 +33,12 @@ def build_profile_image(profile):
         return (profile.image_name, False, error_msg)
 
 
-def build_all_images(max_workers=4, profile_filter=None, proceed=False):
+def build_all_images(workers=4, profile_filter=None, proceed=False):
     """
     Build Docker images for all registered profiles in parallel.
 
     Args:
-        max_workers: Maximum number of parallel workers
+        workers: Maximum number of parallel workers
         profile_filter: Optional list of profile mirror names to filter by
         proceed: Whether to proceed without confirmation
 
@@ -94,7 +94,7 @@ def build_all_images(max_workers=4, profile_filter=None, proceed=False):
     with tqdm(
         total=len(profiles_to_build), smoothing=0, desc="Building environment images"
     ) as pbar:
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
             # Submit all build tasks
             future_to_profile = {
                 executor.submit(build_profile_image, profile): profile
@@ -128,7 +128,7 @@ def main():
         description="Build Docker images for all registered repository profiles"
     )
     parser.add_argument(
-        "--max-workers",
+        "--workers",
         type=int,
         default=4,
         help="Maximum number of parallel workers (default: 4)",
@@ -155,7 +155,7 @@ def main():
         return
 
     successful, failed = build_all_images(
-        max_workers=args.max_workers, profile_filter=args.profiles, proceed=args.proceed
+        workers=args.workers, profile_filter=args.profiles, proceed=args.proceed
     )
 
     if failed:

--- a/swesmith/harness/eval.py
+++ b/swesmith/harness/eval.py
@@ -5,7 +5,7 @@ Usage: python -m swesmith.harness.eval \
     --dataset_path <path to dataset> \
     --predictions_path <gold / path to predictions> \
     --run_id <unique identifier for this run> \
-    --max_workers <number of workers to use>
+    --workers <number of workers to use>
 """
 
 import argparse
@@ -80,7 +80,7 @@ def run_evaluation(
 
 def main(
     run_id: str,
-    max_workers: int,
+    workers: int,
     predictions_path: str = "gold",
     dataset_path: str = HF_DATASET,
     instance_ids: list | None = None,
@@ -170,7 +170,7 @@ def main(
     if report_only:
         print("Regenerating reports only (skipping eval run)")
     else:
-        run_threadpool(run_evaluation, payloads, max_workers)
+        run_threadpool(run_evaluation, payloads, workers)
         print("All instances run.")
 
     # Get number of task instances resolved
@@ -215,7 +215,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--run_id", type=str, help="Unique identifier for this run")
     parser.add_argument(
-        "-w", "--max_workers", type=int, help="Number of workers to use", default=4
+        "-w", "--workers", type=int, help="Number of workers to use", default=4
     )
     parser.add_argument(
         "--redo_existing",

--- a/swesmith/harness/eval.py
+++ b/swesmith/harness/eval.py
@@ -33,6 +33,7 @@ def run_evaluation(
     pred: dict,
     instance: dict,
     run_id: str,
+    f2p_only: bool = False,
     is_gold: bool = False,
 ) -> None:
     """
@@ -47,6 +48,7 @@ def run_evaluation(
         rp.timeout,
         patch=pred[KEY_PREDICTION],
         commit=instance_id,  # NOTE: could use `base_commit`
+        f2p_only=f2p_only,
         is_gold=is_gold,
     )
 
@@ -69,7 +71,7 @@ def run_evaluation(
     # Get report from test output
     logger.info(f"Grading answer for {instance_id}...")
     eval_folder = RUN_EVALUATION_LOG_DIR / run_id
-    report = get_eval_report(pred, instance, test_log_path)
+    report = get_eval_report(pred, instance, test_log_path, f2p_only=f2p_only)
     report[KEY_MODEL] = pred[KEY_MODEL]
 
     # Write report to report.json
@@ -83,6 +85,7 @@ def main(
     workers: int,
     predictions_path: str = "gold",
     dataset_path: str = HF_DATASET,
+    f2p_only: bool = False,
     instance_ids: list | None = None,
     report_only: bool = False,
     redo_existing: bool = False,
@@ -162,6 +165,7 @@ def main(
                 prediction,
                 instance,
                 run_id,
+                f2p_only,
                 is_gold,
             )
         )
@@ -224,6 +228,12 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-i", "--instance_ids", type=str, help="Instance IDs to evaluate", nargs="+"
+    )
+    parser.add_argument(
+        "-f",
+        "--f2p_only",
+        action="store_true",
+        help="(Speed up) Run evaluation using only files with f2p tests",
     )
     parser.add_argument(
         "--report_only", action="store_true", help="Regenerate reports only"

--- a/swesmith/harness/grading.py
+++ b/swesmith/harness/grading.py
@@ -68,20 +68,7 @@ def get_valid_report(
 
     for test_case in postgold_sm:
         if test_case not in pregold_sm:
-            if rp.min_testing:
-                # If min_testing is enabled, we ignore the test case
-                # if it is not present in the pre-gold (bug) log
-                continue
-            elif postgold_sm[test_case] == TestStatus.PASSED.value:
-                # If the test case is not present in the pre-gold
-                # log and is passing in the post-gold log, it is
-                # considered a fail-to-pass case
-                report[FAIL_TO_PASS].append(test_case)
-            elif postgold_sm[test_case] == TestStatus.FAILED.value:
-                # If the test case is not present in the pre-gold
-                # log and is failing in the post-gold log, it is
-                # considered a pass-to-fail case
-                report[PASS_TO_FAIL].append(test_case)
+            continue
         elif (
             pregold_sm[test_case] == TestStatus.PASSED.value
             and postgold_sm[test_case] == TestStatus.PASSED.value
@@ -102,16 +89,6 @@ def get_valid_report(
             and postgold_sm[test_case] == TestStatus.FAILED.value
         ):
             report[PASS_TO_FAIL].append(test_case)
-
-    for test_case in pregold_sm:
-        if (
-            pregold_sm[test_case] == TestStatus.FAILED.value
-            and test_case not in postgold_sm
-        ):
-            # If the test case was failing in the pre-gold log and
-            # is not present in the post-gold log, it is considered
-            # a fail-to-pass case
-            report[FAIL_TO_PASS].append(test_case)
 
     return report
 

--- a/swesmith/harness/grading.py
+++ b/swesmith/harness/grading.py
@@ -194,11 +194,13 @@ def get_eval_report(
     prediction: dict,
     inst: dict,
     test_log_path: str,
+    f2p_only: bool = False,
 ):
     report_map = {
         "patch_exists": False,
         "resolved": False,
     }
+    rp = global_registry.get_from_inst(inst)
 
     # Check if model patch exists
     if prediction[KEY_PREDICTION] is None:
@@ -209,7 +211,20 @@ def get_eval_report(
     test_output, found = read_test_output(test_log_path)
     if not found:
         return report_map
-    test_status_map = global_registry.get_from_inst(inst).log_parser(test_output)
+    test_status_map = rp.log_parser(test_output)
+
+    if f2p_only:
+        # Only examine f2p tests
+        test_files = rp._get_f2p_test_files(inst)
+        filter_irrelevant_tests = (
+            lambda tests: [
+                x for x in tests if any([x.startswith(y) for y in test_files])
+            ]
+            if len(test_files) > 0
+            else tests
+        )
+        inst[FAIL_TO_PASS] = filter_irrelevant_tests
+        inst[PASS_TO_PASS] = filter_irrelevant_tests
 
     # Get evaluation test report
     report = get_eval_tests_report(test_status_map, inst)

--- a/swesmith/harness/grading.py
+++ b/swesmith/harness/grading.py
@@ -92,6 +92,20 @@ def get_valid_report(
     return report
 
 
+def test_passed(case: str, sm: dict[str, str]) -> bool:
+    return case in sm and sm[case] in [
+        TestStatus.PASSED.value,
+        TestStatus.XFAIL.value,
+    ]
+
+
+def test_failed(case: str, sm: dict[str, str]) -> bool:
+    return case not in sm or sm[case] in [
+        TestStatus.FAILED.value,
+        TestStatus.ERROR.value,
+    ]
+
+
 def get_eval_tests_report(
     eval_status_map: dict[str, str],
     gold_results: dict[str, str],
@@ -119,37 +133,23 @@ def get_eval_tests_report(
     - Fail-Fail (F2F) + P: Success (Extra Credit)
     - Pass-Fail (P2F) + P: Not considered
     """
-
-    def test_passed(case: str, sm: dict[str, str]) -> bool:
-        return case in sm and sm[case] in [
-            TestStatus.PASSED.value,
-            TestStatus.XFAIL.value,
-        ]
-
-    def test_failed(case: str, sm: dict[str, str]) -> bool:
-        return case not in sm or sm[case] in [
-            TestStatus.FAILED.value,
-            TestStatus.ERROR.value,
-        ]
-
-    def check_pass_and_fail(test_case, eval_status_map, success, failed):
-        if test_passed(test_case, eval_status_map):
-            # Assume silent success for now (test case not in eval_sm)
-            success.append(test_case)
-        elif test_failed(test_case, eval_status_map):
-            failed.append(test_case)
-
     # Calculate resolution metrics
     f2p_success = []
     f2p_failure = []
     for test_case in gold_results[FAIL_TO_PASS]:
-        check_pass_and_fail(test_case, eval_status_map, f2p_success, f2p_failure)
+        if test_passed(test_case, eval_status_map):
+            f2p_success.append(test_case)
+        elif test_failed(test_case, eval_status_map):
+            f2p_failure.append(test_case)
 
     # Calculate maintenance metrics
     p2p_success = []
     p2p_failure = []
     for test_case in gold_results[PASS_TO_PASS]:
-        check_pass_and_fail(test_case, eval_status_map, p2p_success, p2p_failure)
+        if test_passed(test_case, eval_status_map):
+            p2p_success.append(test_case)
+        elif test_failed(test_case, eval_status_map):
+            p2p_failure.append(test_case)
 
     results = {
         FAIL_TO_PASS: {
@@ -169,11 +169,16 @@ def get_eval_tests_report(
     if calculate_to_fail:
         # Calculate "extra credit" metrics
         for test_case in gold_results[FAIL_TO_FAIL]:
-            check_pass_and_fail(test_case, eval_status_map, f2f_success, f2f_failure)
-
+            if test_passed(test_case, eval_status_map):
+                f2f_success.append(test_case)
+            elif test_failed(test_case, eval_status_map):
+                f2f_failure.append(test_case)
         # Calculate not considered metrics
         for test_case in gold_results[PASS_TO_FAIL]:
-            check_pass_and_fail(test_case, eval_status_map, p2f_success, p2f_failure)
+            if test_passed(test_case, eval_status_map):
+                p2f_success.append(test_case)
+            elif test_failed(test_case, eval_status_map):
+                p2f_failure.append(test_case)
 
     results.update(
         {

--- a/swesmith/harness/grading.py
+++ b/swesmith/harness/grading.py
@@ -3,7 +3,6 @@ from swebench.harness.constants import (
     APPLY_PATCH_FAIL,
     FAIL_TO_FAIL,
     FAIL_TO_PASS,
-    KEY_INSTANCE_ID,
     KEY_PREDICTION,
     PASS_TO_FAIL,
     PASS_TO_PASS,
@@ -196,19 +195,13 @@ def get_eval_report(
     inst: dict,
     test_log_path: str,
 ):
-    report_map = {}
-
-    instance_id = prediction[KEY_INSTANCE_ID]
     report_map = {
-        "patch_is_None": False,
         "patch_exists": False,
-        "patch_successfully_applied": False,
         "resolved": False,
     }
 
     # Check if model patch exists
     if prediction[KEY_PREDICTION] is None:
-        report_map["patch_is_None"] = True
         return report_map
     report_map["patch_exists"] = True
 
@@ -216,25 +209,10 @@ def get_eval_report(
     test_output, found = read_test_output(test_log_path)
     if not found:
         return report_map
-    test_status_map = global_registry.get(inst["repo"]).log_parser(test_output)
-
-    # Identify relevant test files
-    _, test_files = global_registry.get(inst["repo"]).get_test_cmd(inst)
-    filter_irrelevant_tests = (
-        lambda tests: [x for x in tests if any([x.startswith(y) for y in test_files])]
-        if len(test_files) > 0
-        else tests
-    )
-
-    # Construct gold test reference object
-    eval_ref = {
-        KEY_INSTANCE_ID: instance_id,
-        FAIL_TO_PASS: filter_irrelevant_tests(inst[FAIL_TO_PASS]),
-        PASS_TO_PASS: filter_irrelevant_tests(inst[PASS_TO_PASS]),
-    }
+    test_status_map = global_registry.get_from_inst(inst).log_parser(test_output)
 
     # Get evaluation test report
-    report = get_eval_tests_report(test_status_map, eval_ref)
+    report = get_eval_tests_report(test_status_map, inst)
     if get_resolution_status(report) == ResolvedStatus.FULL.value:
         report_map["resolved"] = True
     report_map["tests_status"] = report

--- a/swesmith/harness/grading.py
+++ b/swesmith/harness/grading.py
@@ -68,20 +68,7 @@ def get_valid_report(
 
     for test_case in postgold_sm:
         if test_case not in pregold_sm:
-            if rp.min_testing:
-                # If min_testing is enabled, we ignore the test case
-                # if it is not present in the pre-gold (bug) log
-                continue
-            elif postgold_sm[test_case] == TestStatus.PASSED.value:
-                # If the test case is not present in the pre-gold
-                # log and is passing in the post-gold log, it is
-                # considered a fail-to-pass case
-                report[FAIL_TO_PASS].append(test_case)
-            elif postgold_sm[test_case] == TestStatus.FAILED.value:
-                # If the test case is not present in the pre-gold
-                # log and is failing in the post-gold log, it is
-                # considered a pass-to-fail case
-                report[PASS_TO_FAIL].append(test_case)
+            continue
         elif (
             pregold_sm[test_case] == TestStatus.PASSED.value
             and postgold_sm[test_case] == TestStatus.PASSED.value
@@ -145,21 +132,13 @@ def get_eval_tests_report(
     """
 
     def test_passed(case: str, sm: dict[str, str]) -> bool:
-        # NOTE: This metric is slightly different than SWE-bench's.
-        # The reason originates in wanting to run the test suite efficently (under 90 seconds)
-        # Because of this design, sometimes, we don't run the full test suite, but a subset of it.
-        # Therefore, if a test case does not appear in the eval_sm, we just assume that it was a pass.
-        # Given the uniformity of the testing procedure for SWE-bench repos, this is a safe assumption.
-        return case not in sm or sm[case] in [
+        return case in sm and sm[case] in [
             TestStatus.PASSED.value,
             TestStatus.XFAIL.value,
         ]
 
     def test_failed(case: str, sm: dict[str, str]) -> bool:
-        # NOTE: This metric is slightly different than SWE-bench's.
-        # In SWE-bench, if a test case does not appear, then it is considered a fail.
-        # Here, we look for explicit failures
-        return case in sm and sm[case] in [
+        return case not in sm or sm[case] in [
             TestStatus.FAILED.value,
             TestStatus.ERROR.value,
         ]

--- a/swesmith/harness/grading.py
+++ b/swesmith/harness/grading.py
@@ -68,7 +68,20 @@ def get_valid_report(
 
     for test_case in postgold_sm:
         if test_case not in pregold_sm:
-            continue
+            if rp.min_testing:
+                # If min_testing is enabled, we ignore the test case
+                # if it is not present in the pre-gold (bug) log
+                continue
+            elif postgold_sm[test_case] == TestStatus.PASSED.value:
+                # If the test case is not present in the pre-gold
+                # log and is passing in the post-gold log, it is
+                # considered a fail-to-pass case
+                report[FAIL_TO_PASS].append(test_case)
+            elif postgold_sm[test_case] == TestStatus.FAILED.value:
+                # If the test case is not present in the pre-gold
+                # log and is failing in the post-gold log, it is
+                # considered a pass-to-fail case
+                report[PASS_TO_FAIL].append(test_case)
         elif (
             pregold_sm[test_case] == TestStatus.PASSED.value
             and postgold_sm[test_case] == TestStatus.PASSED.value

--- a/swesmith/harness/utils.py
+++ b/swesmith/harness/utils.py
@@ -71,6 +71,7 @@ def run_patch_in_container(
     timeout: int,
     patch: str | None = None,
     commit: str | None = None,
+    f2p_only: bool = False,
     is_gold: bool = False,
 ) -> tuple[Logger, bool] | None:
     """
@@ -136,7 +137,7 @@ def run_patch_in_container(
 
         # Copy eval script to container
         eval_file = Path(log_dir / "eval.sh")
-        test_command, _ = rp.get_test_cmd(instance)
+        test_command, _ = rp.get_test_cmd(instance, f2p_only=f2p_only)
         eval_file.write_text(
             "\n".join(
                 [

--- a/swesmith/harness/valid.py
+++ b/swesmith/harness/valid.py
@@ -1,7 +1,7 @@
 """
 Purpose: Transform a bunch of patches that cause bugs into a SWE-bench style dataset.
 
-Usage: python -m swesmith.harness.valid logs/bug_gen/*_patches.json --max_workers #
+Usage: python -m swesmith.harness.valid logs/bug_gen/*_patches.json --workers #
 """
 
 import argparse
@@ -138,7 +138,7 @@ def run_validation(instance: dict) -> None:
 
 def main(
     bug_patches: str,
-    max_workers: int,
+    workers: int,
     redo_existing: bool = False,
 ) -> None:
     # Bug patch should be a dict that looks like this:
@@ -214,7 +214,7 @@ def main(
         for bug_patch in bug_patches:
             payloads.append((bug_patch,))
 
-    run_threadpool(run_validation, payloads, max_workers)
+    run_threadpool(run_validation, payloads, workers)
     print("All instances run.")
     print_report(log_dir_parent)
 
@@ -229,7 +229,7 @@ if __name__ == "__main__":
         help="Json file containing bug patches.",
     )
     parser.add_argument(
-        "-w", "--max_workers", type=int, default=4, help="Number of workers to use."
+        "-w", "--workers", type=int, default=4, help="Number of workers to use."
     )
     parser.add_argument(
         "--redo_existing",

--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -18,7 +18,7 @@ from ghapi.all import GhApi
 from multiprocessing import Lock
 from pathlib import Path
 from swesmith.bug_gen.adapters import get_entities_from_file, SUPPORTED_EXTS
-from swebench.harness.constants import FAIL_TO_PASS, KEY_INSTANCE_ID
+from swebench.harness.constants import KEY_INSTANCE_ID
 from swesmith.constants import (
     KEY_PATCH,
     LOG_DIR_ENV,
@@ -253,15 +253,6 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
             f"WARNING: {instance[KEY_INSTANCE_ID]} not from {self.repo_name}"
         )
         test_command = self.test_cmd
-
-        if FAIL_TO_PASS in instance:
-            # NOTE: Using F2P key as indicator that this is eval instance, not validation
-            if "pytest" in test_command:
-                f2p_files = sorted(
-                    list(set([x.split("::", 1)[0] for x in instance[FAIL_TO_PASS]]))
-                )
-                test_command += f" {' '.join(f2p_files)}"
-                return test_command, f2p_files
 
         if not self.min_testing or KEY_PATCH not in instance:
             # If min testing is not enabled or there's no patch

--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -18,7 +18,7 @@ from ghapi.all import GhApi
 from multiprocessing import Lock
 from pathlib import Path
 from swesmith.bug_gen.adapters import get_entities_from_file, SUPPORTED_EXTS
-from swebench.harness.constants import KEY_INSTANCE_ID
+from swebench.harness.constants import FAIL_TO_PASS, KEY_INSTANCE_ID
 from swesmith.constants import (
     KEY_PATCH,
     LOG_DIR_ENV,
@@ -112,6 +112,10 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
             return True
         except:
             return False
+
+    def _get_f2p_test_files(self, instance: dict):
+        """Given an instance, return files corresponding to F2P tests"""
+        return instance[FAIL_TO_PASS]
 
     def build_image(self):
         """Build a Docker image (execution environment) for this repository profile."""
@@ -248,11 +252,18 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
 
         return self._test_paths_cache[cache_key]
 
-    def get_test_cmd(self, instance: dict) -> tuple[str, list[Path]]:
+    def get_test_cmd(
+        self, instance: dict, f2p_only: bool = False
+    ) -> tuple[str, list[Path]]:
         assert instance[KEY_INSTANCE_ID].rsplit(".", 1)[0] == self.repo_name, (
             f"WARNING: {instance[KEY_INSTANCE_ID]} not from {self.repo_name}"
         )
         test_command = self.test_cmd
+
+        if f2p_only:
+            f2p_files = self._get_f2p_test_files(instance)
+            test_command += f" {' '.join(f2p_files)}"
+            return test_command, f2p_files
 
         if not self.min_testing or KEY_PATCH not in instance:
             # If min testing is not enabled or there's no patch

--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -107,11 +107,11 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
 
     def _mirror_exists(self):
         """Check if mirror repository exists under organization"""
-        return self.repo_name in [
-            x["name"]
-            for page in range(1, 5)  # TODO: Need to update over time
-            for x in api.repos.list_for_org(self.org_gh, per_page=100, page=page)
-        ]
+        try:
+            api.repos.get(owner=self.org_gh, repo=self.repo_name)
+            return True
+        except:
+            return False
 
     def build_image(self):
         """Build a Docker image (execution environment) for this repository profile."""

--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -61,12 +61,12 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
     org_gh: str = ORG_NAME_GH
     arch: str = "x86_64" if platform.machine() not in {"aarch64", "arm64"} else "arm64"
     pltf: str = "linux/x86_64" if arch == "x86_64" else "linux/arm64/v8"
+    exts: list[str] = field(
+        default_factory=lambda: [f".{ext}" for ext in SUPPORTED_EXTS]
+    )
 
     # Install + Test specifications
     test_cmd: str = ""
-    test_exts: list[str] = field(
-        default_factory=lambda: [f".{ext}" for ext in SUPPORTED_EXTS]
-    )
     timeout: int = 90  # timeout (sec) for running test suite for a single instance
     timeout_ref: int = 900  # timeout for running entire test suite
 
@@ -237,8 +237,8 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
                             or file.rsplit(".", 1)[0].endswith("test")
                         )
                         and (
-                            len(self.test_exts) == 0
-                            or any([file.endswith(ext) for ext in self.test_exts])
+                            len(self.exts) == 0
+                            or any([file.endswith(ext) for ext in self.exts])
                         )
                     )
                 ]
@@ -380,7 +380,7 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
                     continue
 
                 file_ext = Path(file_path).suffix[1:]
-                if file_ext not in get_entities_from_file:
+                if file_ext not in get_entities_from_file or file_ext not in self.exts:
                     continue
                 get_entities_from_file[file_ext](entities, file_path, max_entities)
         if cloned:

--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -67,8 +67,8 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
     test_exts: list[str] = field(
         default_factory=lambda: [f".{ext}" for ext in SUPPORTED_EXTS]
     )
-    timeout: int = 60  # timeout (sec) for running test suite for a single instance
-    timeout_ref: int = 600  # timeout for running entire test suite
+    timeout: int = 90  # timeout (sec) for running test suite for a single instance
+    timeout_ref: int = 900  # timeout for running entire test suite
 
     # `min_testing`: If set, then subset of tests (not all) are run for post-bug validation
     # Affects get_test_cmd, get_valid_report
@@ -109,7 +109,7 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
         """Check if mirror repository exists under organization"""
         return self.repo_name in [
             x["name"]
-            for page in range(1, 3)  # TODO: Need to update over time
+            for page in range(1, 5)  # TODO: Need to update over time
             for x in api.repos.list_for_org(self.org_gh, per_page=100, page=page)
         ]
 

--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -61,9 +61,7 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
     org_gh: str = ORG_NAME_GH
     arch: str = "x86_64" if platform.machine() not in {"aarch64", "arm64"} else "arm64"
     pltf: str = "linux/x86_64" if arch == "x86_64" else "linux/arm64/v8"
-    exts: list[str] = field(
-        default_factory=lambda: [f".{ext}" for ext in SUPPORTED_EXTS]
-    )
+    exts: list[str] = field(default_factory=lambda: SUPPORTED_EXTS)
 
     # Install + Test specifications
     test_cmd: str = ""
@@ -379,8 +377,8 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
                 except:
                     continue
 
-                file_ext = Path(file_path).suffix[1:]
-                if file_ext not in get_entities_from_file or file_ext not in self.exts:
+                file_ext = Path(file_path).suffix
+                if file_ext not in self.exts:
                     continue
                 get_entities_from_file[file_ext](entities, file_path, max_entities)
         if cloned:

--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -18,7 +18,7 @@ from ghapi.all import GhApi
 from multiprocessing import Lock
 from pathlib import Path
 from swesmith.bug_gen.adapters import get_entities_from_file, SUPPORTED_EXTS
-from swebench.harness.constants import FAIL_TO_PASS, KEY_INSTANCE_ID
+from swebench.harness.constants import KEY_INSTANCE_ID
 from swesmith.constants import (
     KEY_PATCH,
     LOG_DIR_ENV,
@@ -112,10 +112,6 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
             return True
         except:
             return False
-
-    def _get_f2p_test_files(self, instance: dict):
-        """Given an instance, return files corresponding to F2P tests"""
-        return instance[FAIL_TO_PASS]
 
     def build_image(self):
         """Build a Docker image (execution environment) for this repository profile."""
@@ -251,6 +247,10 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
                 self._test_paths_cache[cache_key] = test_paths
 
         return self._test_paths_cache[cache_key]
+
+    def _get_f2p_test_files(self, instance: dict):
+        """Given an instance, return files corresponding to F2P tests"""
+        raise NotImplementedError("F2P test file identification not implemented")
 
     def get_test_cmd(
         self, instance: dict, f2p_only: bool = False

--- a/swesmith/profiles/golang.py
+++ b/swesmith/profiles/golang.py
@@ -1,6 +1,6 @@
 import re
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from swebench.harness.constants import TestStatus
 from swesmith.profiles.base import RepoProfile, global_registry
 
@@ -14,6 +14,7 @@ class GoProfile(RepoProfile):
     repository profiles.
     """
 
+    exts: list[str] = field(default_factory=lambda: [".go"])
     test_cmd: str = "go test -v ./..."
 
     @property

--- a/swesmith/profiles/golang.py
+++ b/swesmith/profiles/golang.py
@@ -344,8 +344,6 @@ class Roaring(GoProfile):
     owner: str = "RoaringBitmap"
     repo: str = "roaring"
     commit: str = "09c46a0a47d21ebbe4bedb01bbcf0ba96f22a46d"
-    timeout: int = 90
-    timeout_ref: int = 90
 
 
 @dataclass

--- a/swesmith/profiles/golang.py
+++ b/swesmith/profiles/golang.py
@@ -14,7 +14,7 @@ class GoProfile(RepoProfile):
     repository profiles.
     """
 
-    test_cmd: str = "go test -v -count=1 ./..."
+    test_cmd: str = "go test -v ./..."
 
     @property
     def dockerfile(self):
@@ -22,6 +22,7 @@ class GoProfile(RepoProfile):
 RUN git clone https://github.com/{self.mirror_name} /testbed
 WORKDIR /testbed
 RUN go mod tidy
+RUN go test -v -count=1 ./... || true
 """
 
     def log_parser(self, log: str) -> dict[str, str]:
@@ -57,13 +58,6 @@ class Fzf976001e4(GoProfile):
     owner: str = "junegunn"
     repo: str = "fzf"
     commit: str = "976001e47459973b5e72565f3047cc9d9e20241d"
-
-
-@dataclass
-class Beego8fd113aa(GoProfile):
-    owner: str = "beego"
-    repo: str = "beego"
-    commit: str = "8fd113aa0937a11c45eb41cbf147f33df7e9fb6f"
 
 
 @dataclass

--- a/swesmith/profiles/python.py
+++ b/swesmith/profiles/python.py
@@ -32,7 +32,7 @@ class PythonProfile(RepoProfile):
     )
     test_exts: list[str] = field(default_factory=lambda: [".py"])
 
-    def _get_f2p_test_files(self, instance: dict):
+    def _get_f2p_test_files(self, instance: dict) -> list[str]:
         return sorted(list(set([x.split("::", 1)[0] for x in instance[FAIL_TO_PASS]])))
 
     def build_image(self):

--- a/swesmith/profiles/python.py
+++ b/swesmith/profiles/python.py
@@ -3,7 +3,7 @@ import re
 from dataclasses import dataclass, field
 
 from pathlib import Path
-from swebench.harness.constants import TestStatus
+from swebench.harness.constants import FAIL_TO_PASS, TestStatus
 from swebench.harness.docker_build import build_image as build_image_sweb
 from swebench.harness.dockerfiles import get_dockerfile_env
 from swesmith.constants import LOG_DIR_ENV, ENV_NAME, INSTANCE_REF
@@ -31,6 +31,9 @@ class PythonProfile(RepoProfile):
         "pytest --disable-warnings --color=no --tb=no --verbose"
     )
     test_exts: list[str] = field(default_factory=lambda: [".py"])
+
+    def _get_f2p_test_files(self, instance: dict):
+        return sorted(list(set([x.split("::", 1)[0] for x in instance[FAIL_TO_PASS]])))
 
     def build_image(self):
         BASE_IMAGE_KEY = "jyangballin/swesmith.x86_64"

--- a/swesmith/profiles/python.py
+++ b/swesmith/profiles/python.py
@@ -30,7 +30,7 @@ class PythonProfile(RepoProfile):
         f"conda activate {ENV_NAME}; "
         "pytest --disable-warnings --color=no --tb=no --verbose"
     )
-    test_exts: list[str] = field(default_factory=lambda: [".py"])
+    exts: list[str] = field(default_factory=lambda: [".py"])
 
     def _get_f2p_test_files(self, instance: dict) -> list[str]:
         return sorted(list(set([x.split("::", 1)[0] for x in instance[FAIL_TO_PASS]])))

--- a/swesmith/profiles/python.py
+++ b/swesmith/profiles/python.py
@@ -3,7 +3,7 @@ import re
 from dataclasses import dataclass, field
 
 from pathlib import Path
-from swebench.harness.constants import FAIL_TO_PASS, TestStatus
+from swebench.harness.constants import TestStatus
 from swebench.harness.docker_build import build_image as build_image_sweb
 from swebench.harness.dockerfiles import get_dockerfile_env
 from swesmith.constants import LOG_DIR_ENV, ENV_NAME, INSTANCE_REF
@@ -1124,11 +1124,7 @@ class MypyE93f06ce(PythonProfile):
 
     def get_test_cmd(self, instance: str) -> tuple[str, list]:
         pattern = r"\[case ([^\]]+)\]"
-        if FAIL_TO_PASS in instance:
-            test_keys = " or ".join(
-                [x.rsplit("::", 1)[-1] for x in instance[FAIL_TO_PASS]]
-            )
-        elif INSTANCE_REF in instance and "test_patch" in instance[INSTANCE_REF]:
+        if INSTANCE_REF in instance and "test_patch" in instance[INSTANCE_REF]:
             test_keys = " or ".join(
                 re.findall(pattern, instance[INSTANCE_REF]["test_patch"])
             )

--- a/tests/profiles/test_base.py
+++ b/tests/profiles/test_base.py
@@ -467,24 +467,6 @@ def test_get_test_cmd_basic():
     assert test_files == []
 
 
-def test_get_test_cmd_eval_mode():
-    """Test get_test_cmd in evaluation mode with FAIL_TO_PASS."""
-    mock_rp = MockRepoProfile("dummy_dir")
-    mock_rp.test_cmd = "pytest"
-
-    instance = {
-        KEY_INSTANCE_ID: "test__test_repo.test1234.suffix",
-        FAIL_TO_PASS: ["test_file.py::test_function", "other_file.py::test_other"],
-    }
-
-    test_command, test_files = mock_rp.get_test_cmd(instance)
-    # Order of files may vary, so check set equality
-    parts = test_command.split()
-    assert parts[0] == "pytest"
-    assert set([str(f) for f in test_files]) == {"test_file.py", "other_file.py"}
-    assert set(parts[1:]) == {"test_file.py", "other_file.py"}
-
-
 def test_get_test_cmd_min_testing():
     """Test get_test_cmd when min_testing is enabled."""
     mock_rp = MockRepoProfile("dummy_dir")

--- a/tests/profiles/test_base.py
+++ b/tests/profiles/test_base.py
@@ -275,25 +275,21 @@ def test_mirror_exists():
     """Test _mirror_exists method"""
     repo_profile = global_registry.get("mewwts__addict.75284f95")
 
-    # Mock the GitHub API response
-    mock_repos = [
-        {"name": "mewwts__addict.75284f95"},
-        {"name": "other_repo"},
-    ]
-
-    with patch("swesmith.profiles.base.api") as mock_api:
-        mock_api.repos.list_for_org.return_value = mock_repos
+    # Test when mirror exists (api.repos.get does not raise)
+    with patch("swesmith.profiles.base.api.repos.get", return_value=None) as mock_get:
         assert repo_profile._mirror_exists() is True
+        mock_get.assert_called_once_with(
+            owner=repo_profile.org_gh, repo=repo_profile.repo_name
+        )
 
-    # Test when mirror doesn't exist
-    mock_repos_no_match = [
-        {"name": "other_repo1"},
-        {"name": "other_repo2"},
-    ]
-
-    with patch("swesmith.profiles.base.api") as mock_api:
-        mock_api.repos.list_for_org.return_value = mock_repos_no_match
+    # Test when mirror does not exist (api.repos.get raises Exception)
+    with patch(
+        "swesmith.profiles.base.api.repos.get", side_effect=Exception("not found")
+    ) as mock_get:
         assert repo_profile._mirror_exists() is False
+        mock_get.assert_called_once_with(
+            owner=repo_profile.org_gh, repo=repo_profile.repo_name
+        )
 
 
 def test_create_mirror():

--- a/tests/profiles/test_profiles_golang.py
+++ b/tests/profiles/test_profiles_golang.py
@@ -148,7 +148,7 @@ def test_go_profile_build_image_subprocess_parameters():
 
 def test_go_profile_go_test_command():
     profile = make_dummy_go_profile()
-    assert profile.test_cmd == "go test -v -count=1 ./..."
+    assert profile.test_cmd == "go test -v ./..."
     assert "go test" in profile.test_cmd
     assert "-v" in profile.test_cmd
     assert "./..." in profile.test_cmd

--- a/tests/test_logs/run_evaluation/getmoto__moto.694ce1f4.pr_7331/report.json
+++ b/tests/test_logs/run_evaluation/getmoto__moto.694ce1f4.pr_7331/report.json
@@ -1,7 +1,5 @@
 {
-    "patch_is_None": false,
     "patch_exists": true,
-    "patch_successfully_applied": false,
     "resolved": true,
     "tests_status": {
         "FAIL_TO_PASS": {

--- a/tests/test_logs/run_evaluation/pandas-dev__pandas.95280573.pr_53652/report.json
+++ b/tests/test_logs/run_evaluation/pandas-dev__pandas.95280573.pr_53652/report.json
@@ -1,7 +1,5 @@
 {
-    "patch_is_None": false,
     "patch_exists": true,
-    "patch_successfully_applied": false,
     "resolved": true,
     "tests_status": {
         "FAIL_TO_PASS": {

--- a/tests/test_logs/run_evaluation/pandas-dev__pandas.95280573.pr_53856/report.json
+++ b/tests/test_logs/run_evaluation/pandas-dev__pandas.95280573.pr_53856/report.json
@@ -1,7 +1,5 @@
 {
-    "patch_is_None": false,
     "patch_exists": true,
-    "patch_successfully_applied": false,
     "resolved": false,
     "tests_status": {
         "FAIL_TO_PASS": {

--- a/tests/test_logs/run_evaluation/pydantic__pydantic.acb0f10f.pr_8316/report.json
+++ b/tests/test_logs/run_evaluation/pydantic__pydantic.acb0f10f.pr_8316/report.json
@@ -1,7 +1,5 @@
 {
-    "patch_is_None": false,
     "patch_exists": true,
-    "patch_successfully_applied": false,
     "resolved": true,
     "tests_status": {
         "FAIL_TO_PASS": {


### PR DESCRIPTION
### Context

In the existing design of SWE-smith, we make several assumptions about a test's status if it doesn't show up in the standard output from when the test suite is run before/after a patch is applied (baked into the `get_valid_report` logic):
* If a test doesn't show up before the patch is applied, and is `PASS` after the patch is applied, we assume the test was failing before (`FAIL_TO_PASS` test)
* If a test doesn't show up before the patch is applied, and is `FAIL` after the patch is applied, we assume the test was passing before (`PASS_TO_FAIL` test)
* If a test is `FAIL` before the patch is applied, and doesn't show up after the patch is applied, we assume the test is passing after (`FAIL_TO_PASS` test)

Consequently, the current design also makes two key choices:
* In `get_eval_tests_report`: If a test doesn't show up after the patch is applied, we automatically assume the test is `PASS`.
* In the `get_test_cmd` implementation, to make evaluation faster, we do *not* run the entire test suite. Instead, we only run the test files containing `FAIL_TO_PASS` tests.
    * As a result, any `PASS_TO_PASS` tests that fall outside of these files are automatically assumed to be passing, because of the `get_eval_tests_report`

The main benefit of this design is that the evaluation is much faster - instead of running the full suite, we only run a fraction of the tests.

---
### Problems with Current Design

However, #24 (along w/ some concurrent works) wisely points out that this design, which (1) assumes non-present tests are passing, and (2) doesn't run the entire test suite, makes it possible to "reward hack" the evaluation.

Specifically, given a task instance, instead of writing a fix, a policy could add bug(s) that causes the test suite to fail to run at all, such that no tests or their statuses show up. The existing evaluation would mark this as correct.

---
### Proposed Fixes

Therefore, this PR makes the general choice to (1) remove the aforementioned assumptions and (2) look for explicit indication that a test has passed.
The main changes are:
* In `get_valid_report`, the assumptions about a test's state if it doesn't show up are removed.
* In `get_eval_tests_report`, a test is only marked as `PASS` if it shows up in the post-patch execution logs. If it doesn't show up, it is assumed to be `FAIL`, *not* `PASS` like before.
* In `get_test_cmd`, we remove logic that only runs the files with `FAIL_TO_PASS` tests for evaluation - instead, the entire test suite is run.
* The logic for only running F2P test files for evaluation is preserved, but is not enabled by default (only runs with `--f2p_only` flag provided)

*Minor Changes*
- Remove `patch_is_None`, `patch_successfully_applied` fields as they weren't being used.
- Remove `filter_irrelevant_tests` helper func in `get_eval_report`, since we're no longer running `FAIL_TO_PASS` tests' files exclusively.
- `max_workers` flag renamed to `workers`
- Rename `test_exts` to `exts`, add check for `exts` in `extract_entities`. This is to enable creating bugs for only specific file types for certain repositories (e.g. for Golang repos, if `exts = ['.go']`, the logic will ignore non-Go files.

These designs should ensure that SWE-smith's evaluation criteria is no longer prone to reward hacking.

The downside is that now, evaluation will take longer (on average ~8-10s instead of 1-2s per instance). However, we can re-introduce such optimizations more carefully in future PRs.