### PR TITLE
Improve adapter type hints

### DIFF
--- a/swesmith/bug_gen/adapters/c.py
+++ b/swesmith/bug_gen/adapters/c.py
@@ -50,7 +50,7 @@ def get_entities_from_file_c(
     entities: list[CEntity],
     file_path: str,
     max_entities: int = -1,
-) -> list[CEntity]:
+) -> None:
     """
     Parse a .c file and return up to max_entities top-level funcs and types.
     If max_entities < 0, collects them all.
@@ -62,13 +62,13 @@ def get_entities_from_file_c(
     root = tree.root_node
     lines = file_content.splitlines()
 
-    def walk(node):
+    def walk(node) -> None:
         # stop if we've hit the limit
         if 0 <= max_entities == len(entities):
             return
 
         # not checking for error nodes here because tree-sitter-c frequently
-        # generates them parsing valid processor directives
+        # generates them parsing valid pre-processor directives
 
         if node.type == "function_definition":
             entities.append(_build_entity(node, lines, file_path))
@@ -81,9 +81,9 @@ def get_entities_from_file_c(
     walk(root)
 
 
-def _build_entity(node, lines, file_path: str) -> CodeEntity:
+def _build_entity(node, lines, file_path: str) -> CEntity:
     """
-    Turn a Tree-sitter node into CodeEntity.
+    Turns a Tree-sitter node into a CEntity object.
     """
     # start_point/end_point are (row, col) zero-based
     start_row, _ = node.start_point

--- a/swesmith/bug_gen/adapters/golang.py
+++ b/swesmith/bug_gen/adapters/golang.py
@@ -39,9 +39,12 @@ class GoEntity(CodeEntity):
             receiver_query, self.node, "receiver_type"
         )
 
-        return (
-            f"{receiver_type}.{func_name}" if receiver_type and func_name else func_name
-        )
+        if receiver_type and func_name:
+            return f"{receiver_type}.{func_name}"
+        elif func_name:
+            return func_name
+        else:
+            return ""
 
     @property
     def signature(self) -> str:
@@ -107,7 +110,7 @@ def get_entities_from_file_go(
     entities: list[GoEntity],
     file_path: str,
     max_entities: int = -1,
-) -> list[GoEntity]:
+) -> None:
     """
     Parse a .go file and return up to max_entities top-level funcs and types.
     If max_entities < 0, collects them all.
@@ -119,7 +122,7 @@ def get_entities_from_file_go(
     root = tree.root_node
     lines = file_content.splitlines()
 
-    def walk(node):
+    def walk(node) -> None:
         # stop if we've hit the limit
         if 0 <= max_entities == len(entities):
             return
@@ -142,9 +145,9 @@ def get_entities_from_file_go(
     walk(root)
 
 
-def _build_entity(node, lines, file_path: str) -> CodeEntity:
+def _build_entity(node, lines, file_path: str) -> GoEntity:
     """
-    Turn a Tree-sitter node into CodeEntity.
+    Turns a Tree-sitter node into a GoEntity object.
     """
     # start_point/end_point are (row, col) zero-based
     start_row, _ = node.start_point

--- a/swesmith/bug_gen/adapters/java.py
+++ b/swesmith/bug_gen/adapters/java.py
@@ -65,7 +65,7 @@ def get_entities_from_file_java(
     entities: list[JavaEntity],
     file_path: str,
     max_entities: int = -1,
-) -> list[JavaEntity]:
+) -> None:
     """
     Parse a .java file and return up to max_entities top-level funcs and types.
     If max_entities < 0, collects them all.
@@ -77,7 +77,7 @@ def get_entities_from_file_java(
     root = tree.root_node
     lines = file_content.splitlines()
 
-    def walk(node):
+    def walk(node) -> None:
         # stop if we've hit the limit
         if 0 <= max_entities == len(entities):
             return
@@ -112,9 +112,9 @@ def _has_body(node) -> bool:
     return False
 
 
-def _build_entity(node, lines, file_path: str) -> CodeEntity:
+def _build_entity(node, lines, file_path: str) -> JavaEntity:
     """
-    Turn a Tree-sitter node into CodeEntity.
+    Turns a Tree-sitter node into a JavaEntity object.
     """
     # start_point/end_point are (row, col) zero-based
     start_row, _ = node.start_point

--- a/swesmith/bug_gen/adapters/ruby.py
+++ b/swesmith/bug_gen/adapters/ruby.py
@@ -60,7 +60,7 @@ class RubyEntity(CodeEntity):
 
     @property
     def complexity(self) -> int:
-        def walk(node):
+        def walk(node) -> int:
             score = 0
 
             if node.type in [
@@ -104,7 +104,7 @@ def get_entities_from_file_rb(
     entities: list[RubyEntity],
     file_path: str,
     max_entities: int = -1,
-) -> list[RubyEntity]:
+) -> None:
     """
     Parse a .rb file and return up to max_entities top-level funcs and types.
     If max_entities < 0, collects them all.
@@ -116,7 +116,7 @@ def get_entities_from_file_rb(
     root = tree.root_node
     lines = file_content.splitlines()
 
-    def walk(node):
+    def walk(node) -> None:
         # stop if we've hit the limit
         if 0 <= max_entities == len(entities):
             return
@@ -141,9 +141,9 @@ def get_entities_from_file_rb(
     walk(root)
 
 
-def _build_entity(node, lines, file_path: str) -> CodeEntity:
+def _build_entity(node, lines, file_path: str) -> RubyEntity:
     """
-    Turn a Tree-sitter node into CodeEntity.
+    Turns a Tree-sitter node into a RubyEntity object.
     """
     # start_point/end_point are (row, col) zero-based
     start_row, _ = node.start_point

--- a/swesmith/bug_gen/adapters/rust.py
+++ b/swesmith/bug_gen/adapters/rust.py
@@ -46,7 +46,7 @@ def get_entities_from_file_rs(
     entities: list[RustEntity],
     file_path: str,
     max_entities: int = -1,
-) -> list[RustEntity]:
+) -> None:
     """
     Parse a .rs file and return up to max_entities top-level funcs and types.
     If max_entities < 0, collects them all.
@@ -58,7 +58,7 @@ def get_entities_from_file_rs(
     root = tree.root_node
     lines = file_content.splitlines()
 
-    def walk(node):
+    def walk(node) -> None:
         # stop if we've hit the limit
         if 0 <= max_entities == len(entities):
             return
@@ -90,9 +90,9 @@ def _has_test_attribute(node) -> bool:
     return False
 
 
-def _build_entity(node, lines, file_path: str) -> CodeEntity:
+def _build_entity(node, lines, file_path: str) -> RustEntity:
     """
-    Turn a Tree-sitter node into CodeEntity.
+    Turns a Tree-sitter node into a RustEntity object.
     """
     # start_point/end_point are (row, col) zero-based
     start_row, _ = node.start_point


### PR DESCRIPTION
Methods implementing `get_entities_from_file` do not return the list of entities, they mutate the existing list.