### PR TITLE
 Update pyproject.toml - Removed jupyter from the list of dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "datasets",
     "docker",
     "ghapi",
-    "jupyter",
     "libcst",
     "litellm",
     "matplotlib",


### PR DESCRIPTION
As discussed in Slack, removing unused bloat