### PR TITLE
Add Rust profiles

### DIFF
--- a/swesmith/profiles/rust.py
+++ b/swesmith/profiles/rust.py
@@ -103,6 +103,7 @@ class Tokioab3ff69c(RustProfile):
     repo: str = "tokio"
     commit: str = "ab3ff69cf2258a8c696b2dca89a2cef4ff114c1c"
     test_cmd: str = "cargo test --verbose --features full -- --skip try_exists"
+    timeout: int = 180
 
 
 @dataclass


### PR DESCRIPTION
Add profiles for Rust repositories.

- I've done some local testing on these but have not pushed any mirrors.
- There are some parsing errors processing [anyhow](https://github.com/dtolnay/anyhow/) which seem to be related to tree-sitter-rust handling of Rust macros.
- The tokio tests take quite a while to run so I've bumped the timeout on those. I also have it skipping the `try_exists` test which reliably failed.
- Our Rust log_parser is currently including the 'test ' prefix from the cargo test output in every test name, we can open a separate PR to remove this.