### PR TITLE
Check exit code when building docker image

### DIFF
--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -177,6 +177,7 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
         with open(env_dir / "build_image.log", "w") as log_file:
             subprocess.run(
                 f"docker build -f {dockerfile_path} --no-cache -t {self.image_name} .",
+                check=True,
                 shell=True,
                 stdout=log_file,
                 stderr=subprocess.STDOUT,

--- a/tests/profiles/test_profiles_golang.py
+++ b/tests/profiles/test_profiles_golang.py
@@ -116,6 +116,19 @@ def test_go_profile_build_image_error_handling():
             profile.build_image()
 
 
+def test_go_profile_build_image_checks_exit_code():
+    profile = make_dummy_go_profile()
+    with (
+        patch("pathlib.Path.mkdir"),
+        patch("builtins.open", mock_open()),
+        patch(
+            "subprocess.run",
+        ) as mock_run,
+    ):
+        profile.build_image()
+        assert mock_run.call_args.kwargs["check"] is True
+
+
 def test_go_profile_build_image_file_operations():
     profile = make_dummy_go_profile()
     with (


### PR DESCRIPTION
- I've added the test here next to similar existing tests in the golang profile tests. However the implementation is actually in base.
- There are likely other usages of `subprocess.run` without passing `check=True` in the codebase, I haven't audited for these yet.