### PR TITLE
Remove "test " prefix from Rust test names

### DIFF
--- a/swesmith/profiles/rust.py
+++ b/swesmith/profiles/rust.py
@@ -14,7 +14,8 @@ class RustProfile(RepoProfile):
 
     def log_parser(self, log: str):
         test_status_map = {}
-        for line in log.split("\n"):
+        for line in log.splitlines():
+            line = line.removeprefix("test ")
             if "... ok" in line:
                 test_name = line.rsplit(" ... ", 1)[0].strip()
                 test_status_map[test_name] = TestStatus.PASSED.value

--- a/tests/profiles/test_profiles_rust.py
+++ b/tests/profiles/test_profiles_rust.py
@@ -1,0 +1,62 @@
+from swesmith.profiles.rust import RustProfile
+
+
+def test_rust_profile_log_parser_basic():
+    profile = RustProfile()
+    log = """
+test test_some_thing ... ok
+test test_some_other_thing ... ok
+test test_some_failure ... FAILED
+
+test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+"""
+    result = profile.log_parser(log)
+    assert len(result) == 3
+    assert result["test_some_thing"] == "PASSED"
+    assert result["test_some_other_thing"] == "PASSED"
+    assert result["test_some_failure"] == "FAILED"
+
+
+def test_rust_profile_log_parser_no_matches():
+    profile = RustProfile()
+    log = """
+running 101 tests
+Some random output
+test result: ok. 101 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+"""
+    result = profile.log_parser(log)
+    assert result == {}
+
+
+def test_rust_profile_log_parser_multiple_test_files():
+    profile = RustProfile()
+    log = """
+     Running `/testbed/some-binary`
+
+running 3 tests
+test test_some_thing ... ok
+test test_some_other_thing ... ok
+test test_some_failure ... FAILED
+
+test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+     Running `/testbed/some-other-binary`
+
+running 2 tests
+test test_another_thing ... ok
+test test_one_more_thing ... ok
+
+test result: PASSED. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+   Doc-tests foo
+test src/lib.rs - Bar (line 123) ... ok
+test result: PASSED. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+"""
+    result = profile.log_parser(log)
+    assert len(result) == 6
+    assert result["test_some_thing"] == "PASSED"
+    assert result["test_some_other_thing"] == "PASSED"
+    assert result["test_some_failure"] == "FAILED"
+    assert result["test_another_thing"] == "PASSED"
+    assert result["test_one_more_thing"] == "PASSED"
+    assert result["src/lib.rs - Bar (line 123)"] == "PASSED"


### PR DESCRIPTION
- Previously we included the leading "test " prefix from the test output in the name of each test. Remove the prefix as it is unnecessary.
- Backfill log parsing tests.