### PR TITLE
Remove profiles of repos present in SWE-bench_Multilingual

### DIFF
--- a/swesmith/profiles/c.py
+++ b/swesmith/profiles/c.py
@@ -1,7 +1,4 @@
-import re
-
 from dataclasses import dataclass
-from swebench.harness.constants import TestStatus
 from swesmith.profiles.base import RepoProfile, registry
 
 
@@ -10,96 +7,6 @@ class CProfile(RepoProfile):
     """
     Profile for C repositories.
     """
-
-
-@dataclass
-class Jqb9e19de76(CProfile):
-    owner: str = "jqlang"
-    repo: str = "jq"
-    commit: str = "b9e19de76e6e19d044007ead65d164710dc98877"
-    test_cmd: str = "make check"
-
-    @property
-    def dockerfile(self):
-        return f"""FROM ubuntu:22.04
-ENV DEBIAN_FRONTEND=noninteractive \
-    DEBCONF_NONINTERACTIVE_SEEN=true \
-    LC_ALL=C.UTF-8 \
-    LANG=C.UTF-8
-ENV TZ=Etc/UTC
-RUN apt-get update \
-    && apt-get install -y build-essential autoconf libtool git \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-RUN git clone https://github.com/{self.mirror_name} /testbed
-WORKDIR /testbed
-RUN git submodule update --init --recursive
-RUN autoreconf -i \
-    && ./configure \
-    --disable-docs \
-    --with-oniguruma=builtin \
-    --enable-static \
-    --enable-all-static \
-    --prefix=/usr/local
-RUN make clean
-RUN touch src/parser.y src/lexer.l
-RUN make -j$(nproc)
-"""
-
-    def log_parser(self, log: str) -> dict[str, str]:
-        test_status_map = {}
-        pattern = r"^\s*(PASS|FAIL):\s(.+)$"
-        for line in log.split("\n"):
-            match = re.match(pattern, line.strip())
-            if match:
-                status, test_name = match.groups()
-                if status == "PASS":
-                    test_status_map[test_name] = TestStatus.PASSED.value
-                elif status == "FAIL":
-                    test_status_map[test_name] = TestStatus.FAILED.value
-        return test_status_map
-
-
-@dataclass
-class Valkeyfc7c04e4(CProfile):
-    owner: str = "valkey-io"
-    repo: str = "valkey"
-    commit: str = "fc7c04e4f8ba86dfbac1ec059db457fb44ed0a2d"
-    test_cmd: str = "TERM=dumb ./runtest --durable"
-
-    @property
-    def dockerfile(self):
-        return f"""FROM ubuntu:22.04
-ARG DEBIAN_FRONTEND=noninteractive
-ENV TZ=Etc/UTC
-RUN sed -i 's/^# deb-src/deb-src/' /etc/apt/sources.list
-RUN apt update && \
-    apt install -y pkg-config wget git build-essential libtool automake autoconf tcl bison flex cmake python3 python3-pip python3-venv python-is-python3 && \
-    rm -rf /var/lib/apt/lists/*
-RUN adduser --disabled-password --gecos 'dog' nonroot
-RUN git clone https://github.com/{self.mirror_name} /testbed
-WORKDIR /testbed
-RUN cd deps/jemalloc && ./autogen.sh
-RUN make distclean
-RUN make
-"""
-
-    def log_parser(self, log: str) -> dict[str, str]:
-        test_status_map = {}
-        pattern = r"^\[(ok|err|skip|ignore)\]:\s(.+?)(?:\s\((\d+\s*m?s)\))?$"
-        for line in log.split("\n"):
-            match = re.match(pattern, line.strip())
-            if match:
-                status, test_name, _duration = match.groups()
-                if status == "ok":
-                    test_status_map[test_name] = TestStatus.PASSED.value
-                elif status == "err":
-                    # Strip out file path information from failed test names
-                    test_name = re.sub(r"\s+in\s+\S+$", "", test_name)
-                    test_status_map[test_name] = TestStatus.FAILED.value
-                elif status == "skip" or status == "ignore":
-                    test_status_map[test_name] = TestStatus.SKIPPED.value
-        return test_status_map
 
 
 # Register all C profiles with the global registry

--- a/swesmith/profiles/golang.py
+++ b/swesmith/profiles/golang.py
@@ -117,24 +117,10 @@ RUN go test -v -count=1 ./... || true
 
 
 @dataclass
-class Gin3c12d2a8(GoProfile):
-    owner: str = "gin-gonic"
-    repo: str = "gin"
-    commit: str = "3c12d2a80e40930632fc4a4a4e1a45140f33fb12"
-
-
-@dataclass
 class Fzf976001e4(GoProfile):
     owner: str = "junegunn"
     repo: str = "fzf"
     commit: str = "976001e47459973b5e72565f3047cc9d9e20241d"
-
-
-@dataclass
-class Caddy77dd12cc(GoProfile):
-    owner: str = "caddyserver"
-    repo: str = "caddy"
-    commit: str = "77dd12cc785990c5c5da947b4e883029ab8bd552"
 
 
 @dataclass

--- a/swesmith/profiles/java.py
+++ b/swesmith/profiles/java.py
@@ -1,7 +1,4 @@
-import re
-
 from dataclasses import dataclass
-from swebench.harness.constants import TestStatus
 from swesmith.profiles.base import RepoProfile, registry
 
 
@@ -10,46 +7,6 @@ class JavaProfile(RepoProfile):
     """
     Profile for Java repositories.
     """
-
-
-@dataclass
-class Gsondd2fe59c(JavaProfile):
-    owner: str = "google"
-    repo: str = "gson"
-    commit: str = "dd2fe59c0d3390b2ad3dd365ed6938a5c15844cb"
-    test_cmd: str = "mvn test -B -T 1C -Dsurefire.useFile=false -Dsurefire.printSummary=true -Dsurefire.reportFormat=plain"
-
-    @property
-    def dockerfile(self):
-        return f"""FROM ubuntu:22.04
-ENV DEBIAN_FRONTEND=noninteractive
-ENV LANG=C.UTF-8
-ENV LC_ALL=C.UTF-8
-RUN apt-get update && apt-get install -y git openjdk-11-jdk
-RUN apt-get install -y maven
-RUN git clone https://github.com/{self.mirror_name} /testbed
-WORKDIR /testbed
-RUN mvn clean install -B -pl gson -DskipTests -am
-"""
-
-    def log_parser(self, log: str) -> dict[str, str]:
-        test_status_map = {}
-        pattern = r"^\[(INFO|ERROR)\]\s+(.*?)\s+--\s+Time elapsed:\s+([\d.]+)\s"
-        for line in log.split("\n"):
-            if line.endswith("<<< FAILURE!") and line.startswith("[ERROR]"):
-                test_name = re.match(pattern, line)
-                if test_name is None:
-                    continue
-                test_status_map[test_name.group(2)] = TestStatus.FAILED.value
-            elif (
-                any([line.startswith(s) for s in ["[INFO]", "[ERROR]"]])
-                and "Time elapsed:" in line
-            ):
-                test_name = re.match(pattern, line)
-                if test_name is None:
-                    continue
-                test_status_map[test_name.group(2)] = TestStatus.PASSED.value
-        return test_status_map
 
 
 # Register all Java profiles with the global registry

--- a/swesmith/profiles/javascript.py
+++ b/swesmith/profiles/javascript.py
@@ -1,11 +1,9 @@
 import re
 
 from dataclasses import dataclass
-from swesmith.constants import KEY_PATCH
 from swebench.harness.constants import TestStatus
 from swesmith.profiles.base import RepoProfile, registry
 from swesmith.profiles.utils import X11_DEPS
-from unidiff import PatchSet
 
 
 @dataclass
@@ -155,37 +153,6 @@ RUN npm test
 
 
 @dataclass
-class Babel2ea3fc8f(JavaScriptProfile):
-    owner: str = "babel"
-    repo: str = "babel"
-    commit: str = "2ea3fc8f9b33a911840f17fbc407e7bfae2ed66f"
-    test_cmd: str = "yarn jest --verbose"
-
-    @property
-    def dockerfile(self):
-        return f"""FROM node:20-bullseye
-RUN apt update && apt install -y git
-RUN git clone https://github.com/{self.mirror_name} /testbed
-WORKDIR /testbed
-RUN make bootstrap
-RUN make build
-"""
-
-    def log_parser(self, log: str) -> dict[str, str]:
-        return parse_log_jest(log)
-
-    def get_test_cmd(self, instance: dict, f2p_only: bool = False):
-        if KEY_PATCH not in instance:
-            return self.test_cmd, []
-        test_folders = []
-        for f in PatchSet(instance[KEY_PATCH]):
-            parts = f.path.split("/")
-            if len(parts) >= 2 and parts[0] == "packages":
-                test_folders.append("/".join(parts[:2]))
-        return f"{self.test_cmd} {' '.join(test_folders)}", test_folders
-
-
-@dataclass
 class GithubReadmeStats3e974011(JavaScriptProfile):
     owner: str = "anuraghazra"
     repo: str = "github-readme-stats"
@@ -206,21 +173,6 @@ class Mongoose5f57a5bb(JavaScriptProfile):
     repo: str = "mongoose"
     commit: str = "5f57a5bbb2e8dfed8d04be47cdd17728633c44c1"  # Replace with a specific commit hash
     test_cmd: str = "npm test -- --verbose"
-
-    @property
-    def dockerfile(self):
-        return default_npm_install_dockerfile(self.mirror_name)
-
-    def log_parser(self, log: str) -> dict[str, str]:
-        return parse_log_mocha(log)
-
-
-@dataclass
-class Axiosef36347f(JavaScriptProfile):
-    owner: str = "axios"
-    repo: str = "axios"
-    commit: str = "ef36347fb559383b04c755b07f1a8d11897fab7f"  # Replace with a specific commit hash
-    test_cmd: str = "npm run test:mocha -- --verbose"
 
     @property
     def dockerfile(self):

--- a/swesmith/profiles/rust.py
+++ b/swesmith/profiles/rust.py
@@ -99,15 +99,6 @@ class Semver37bcbe69(RustProfile):
 
 
 @dataclass
-class Tokioab3ff69c(RustProfile):
-    owner: str = "tokio-rs"
-    repo: str = "tokio"
-    commit: str = "ab3ff69cf2258a8c696b2dca89a2cef4ff114c1c"
-    test_cmd: str = "cargo test --verbose --features full -- --skip try_exists"
-    timeout: int = 180
-
-
-@dataclass
 class Uuid2fd9b614(RustProfile):
     owner: str = "uuid-rs"
     repo: str = "uuid"

--- a/tests/profiles/test_base.py
+++ b/tests/profiles/test_base.py
@@ -134,8 +134,8 @@ def test_python_log_parser():
 
 
 def test_golang_log_parser():
-    # Use Gin3c12d2a8 Go profile
-    key = "gin-gonic__gin.3c12d2a8"
+    # Use Natsserver2ee2e24c Go profile
+    key = "nats-io__nats-server.2ee2e24c"
     repo_profile = registry.get(key)
     log = """
 --- PASS: TestFoo (0.01s)

--- a/tests/profiles/test_profiles_golang.py
+++ b/tests/profiles/test_profiles_golang.py
@@ -1,7 +1,7 @@
 import pytest
 import subprocess
 
-from swesmith.profiles.golang import GoProfile, Gin3c12d2a8
+from swesmith.profiles.golang import GoProfile
 from unittest.mock import patch, mock_open
 
 
@@ -165,13 +165,3 @@ def test_go_profile_go_test_command():
     assert "go test" in profile.test_cmd
     assert "-v" in profile.test_cmd
     assert "./..." in profile.test_cmd
-
-
-def test_gin_profile_dockerfile_content():
-    # This test is Gin-specific and checks the Gin profile's Dockerfile
-    profile = Gin3c12d2a8()
-    dockerfile = profile.dockerfile
-    assert "FROM golang:1.24" in dockerfile
-    assert f"git clone https://github.com/{profile.mirror_name}" in dockerfile
-    assert "WORKDIR /testbed" in dockerfile
-    assert "go mod tidy" in dockerfile


### PR DESCRIPTION
- Remove repo profiles for repos that are present in SWE-bench_Multilingual: https://huggingface.co/datasets/SWE-bench/SWE-bench_Multilingual
- Update tests where they had references to these profiles
- Leaving CProfile and JavaProfile in place even though there are no repos defined for these now