### PR TITLE
Add `eval_sets` field to specify if repos are part of test sets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,9 @@ Each of these is described in more detail below. The priority level is indicated
 * 🟠 `p2` - Medium priority
 * 🟡 `p3` - Low priority
 
-### Support New Languages
+<hr />
+
+## Support New Languages
 
 🟡 `p3`
 
@@ -32,7 +34,9 @@ The best way to undestand this is by looking at the PRs and existing adapters, s
 
 If you need help, open an issue and ask [@acrmp](https://github.com/acrmp), [@john-b-yang](https://github.com/john-b-yang), or [@klieret](https://github.com/klieret) for help! To contribute, make a new PR with the corresponding code.
 
-### Support New Repositories
+<hr />
+
+## Support New Repositories
 
 🔴 `p1` (Especially non-Python repos)
 
@@ -49,11 +53,48 @@ We've annotated `RepoProfile` in `swesmith/profiles/base.py` with docstrings to 
 
 Check out [#116](https://github.com/SWE-bench/SWE-smith/pull/116) and [d8b20f3f](https://github.com/SWE-bench/SWE-smith/commit/d8b20f3f2ee13e8c9b6ef9495c25e9704008d07a) for examples of PRs / commits that added new repositories.
 
+> [!NOTE]
+> You may need to populate the `eval_sets` property. See [#136](https://github.com/SWE-bench/SWE-smith/pull/136) for an explanation.
+> 
+> tl;dr - There's several SWE-bench style benchmarks out there. If we add a repo that's also used in one of these benchmarks, we want to indicate this in the `eval_sets` property.
+> This way, if we want to train repos on a specific benchmark, we know which ones to exclude.
+>
+> <details>
+>      <summary>⚠️ Run this check after adding repos:</summary>
+>
+> ```python
+> from swesmith.profiles import registry
+> from datasets import load_dataset
+> 
+> sb = set(load_dataset("SWE-bench/SWE-bench_Verified", split="test")["repo"])
+> sbmm = set(load_dataset("SWE-bench/SWE-bench_Multimodal", split="test")["repo"])
+> sbml = set(load_dataset("SWE-bench/SWE-bench_Multilingual", split="test")["repo"])
+> 
+> profiles = {
+>     f"{rp.owner}/{rp.repo}": rp.eval_sets
+>     for rp in registry.values()
+> }
+> 
+> for test_repos, test_set in [
+>     (sb, "SWE-bench_Verified"),
+>     (sbmm, "SWE-bench_Multimodal"),
+>     (sbml, "SWE-bench_Multilingual"),
+> ]:
+>     for repo in test_repos:
+>         if repo not in profiles:
+>             continue
+>         if test_set not in profiles[repo]:
+>             print(f"Add {test_set} to {repo}'s `eval_sets` property")
+> ```
+> </details>
+
 We're always looking to add more repositories, so if you have a favorite open-source project, please consider adding it! To contribute, make a new PR with the corresponding code.
 
-If you need help, open an issue and ask [@richardzhuang0412](https://github.com/richardzhuang0412), [@john-b-yang](https://github.com/john-b-yang), or [@klieret](https://github.com/klieret) for help!
+If you need help, open an issue and ask [@richardzhuang0412](https://github.com/richardzhuang0412), [@acrmp](https://github.com/acrmp), [@john-b-yang](https://github.com/john-b-yang), or [@klieret](https://github.com/klieret) for help!
 
-### Create task instances
+<hr />
+
+## Create task instances
 
 🔴 `p1` (Especially non-Python repos)
 
@@ -73,7 +114,9 @@ From there, we then perform the following additional steps:
 * `python swesmith/harness/gather.py logs/run_validation/<repo>`, to collect the bugs into a single `logs/task_insts/<repo>.json` file and push valid bugs as branches to the corresponding repository under the [SWE-smith](https://github.com/orgs/swesmith/repositories) organization.
 * Push the new bugs to the [SWE-bench/SWE-smith HF dataset](https://huggingface.co/datasets/SWE-bench/SWE-smith) for all of us to use!
 
-### Add problem statements
+<hr />
+
+## Add problem statements
 
 🔴 `p1`
 
@@ -89,7 +132,9 @@ This command will populate a `logs/issue_gen/` folder with problem statements fo
 Zip this folder, then upload the zipped file as a new PR.
 From there, we will attach the problem statements to the corresponding task instances in the [SWE-bench/SWE-smith HF dataset](https://huggingface.co/datasets/SWE-bench/SWE-smith), and push!
 
-### Miscellaneous
+<hr />
+
+## Miscellaneous
 
 Here are some ideas and contributions that we're not prioritizing at the moment, but if you're interested, we'd love to help you make it happen!
 Open an issue indicating you're interested, and we'll help you get started.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 Updated 7/21/2025
 
 Thanks for your interest!
-First, make sure to [install](https://swesmith.com/getting_started/installation/) SWE-smith, which should be super easy!
+First, make sure to [install](https://swesmith.com/getting_started/installation.html) SWE-smith, which should be super easy!
 Then, there's several ways to contribute.
 
 * Add support for new languages
@@ -99,7 +99,7 @@ If you need help, open an issue and ask [@richardzhuang0412](https://github.com/
 🔴 `p1` (Especially non-Python repos)
 
 Generating task instances is very easy.
-* The ["Create Instances"](https://swesmith.com/guides/create_instances/) section of the SWE-smith docs describes this repository's bug generation strategies in detail.
+* The ["Create Instances"](https://swesmith.com/guides/create_instances.html) section of the SWE-smith docs describes this repository's bug generation strategies in detail.
 * The [Youtube Playlist](https://youtube.com/playlist?list=PL1b-qYhmIXEhyaUafmTYmMI4l9dbCLNix&si=7xnYixLc7MJSy7UU) shows you what things should look like when you run the scripts.
 * `scripts/cheatsheet.sh` contains the CLI commands to run scripts. Re-adapt these commands to a new repository, and run.
 
@@ -139,7 +139,7 @@ From there, we will attach the problem statements to the corresponding task inst
 Here are some ideas and contributions that we're not prioritizing at the moment, but if you're interested, we'd love to help you make it happen!
 Open an issue indicating you're interested, and we'll help you get started.
 
-* Make [Procedural Modification](https://swesmith.com/guides/create_instances/#procedural-modification) bug generation work for non-Python repos
+* Make [Procedural Modification](https://swesmith.com/guides/create_instances.html#procedural-modification) bug generation work for non-Python repos
 * Add bug generation strategies
     * Create instances corresponding to "subtasks" of SWE-bench. E.g. file localization, patch repair.
 * Add SWE-agent trajectories

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ SWE-smith is a toolkit for training [SWE-agents](https://github.com/SWE-agent/SW
 * Train an LM to become a better SWE ([SWE-agent-LM-32B](https://huggingface.co/SWE-bench/SWE-agent-LM-32B)).
 
 ## ⚒️ Build Environments
-If you're interested in turning a GitHub repository into a SWE-gym, install the package from [source](https://swesmith.com/getting_started/installation/).
+If you're interested in turning a GitHub repository into a SWE-gym, install the package from [source](https://swesmith.com/getting_started/installation.html).
 
 > [!TIP]
 > SWE-smith requires Docker to create execution environments. SWE-smith was developed and tested on Ubuntu 22.04.4 LTS.
@@ -37,7 +37,7 @@ If you're interested in turning a GitHub repository into a SWE-gym, install the 
 
 You can then build a dataset for the repository by...
 1. [Creating an environment](https://swesmith.com/guides/env_construction/#create-an-execution-environment)
-2. [Synthesizing task instances](https://swesmith.com/guides/create_instances/)
+2. [Synthesizing task instances](https://swesmith.com/guides/create_instances.html)
 3. [Keep tasks that break 1+ unit tests](https://swesmith.com/guides/harnesses/)
 4. [Generating issue text for your tasks](https://swesmith.com/guides/issue_gen/)
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ If you're interested in turning a GitHub repository into a SWE-gym, install the 
 > We do *not* plan on supporting Windows or MacOS.
 
 You can then build a dataset for the repository by...
-1. [Creating an environment](https://swesmith.com/guides/env_construction/#create-an-execution-environment)
+1. [Creating an environment](https://swesmith.com/guides/env_construction.html#create-an-execution-environment)
 2. [Synthesizing task instances](https://swesmith.com/guides/create_instances.html)
-3. [Keep tasks that break 1+ unit tests](https://swesmith.com/guides/harnesses/)
-4. [Generating issue text for your tasks](https://swesmith.com/guides/issue_gen/)
+3. [Keep tasks that break 1+ unit tests](https://swesmith.com/guides/harnesses.html)
+4. [Generating issue text for your tasks](https://swesmith.com/guides/issue_gen.html)
 
 ## 🏋️ Train SWE-agent's
 Training SWE-agent's using the [SWE-smith dataset](https://huggingface.co/datasets/SWE-bench/SWE-smith) is super simple.
@@ -55,7 +55,7 @@ for task in ds:
 ```
 
 SWE-smith has been used to
-* Fine-tune Qwen 2.5 Coder into SWE-agent-LM-32B (A +32% jump on SWE-bench Verified!) using [SWE-agent](https://github.com/SWE-agent/SWE-agent) [[Tutorial](https://swesmith.com/guides/train_swe_agent/)]
+* Fine-tune Qwen 2.5 Coder into SWE-agent-LM-32B (A +32% jump on SWE-bench Verified!) using [SWE-agent](https://github.com/SWE-agent/SWE-agent) [[Tutorial](https://swesmith.com/guides/train_swe_agent.html)]
 * Perform GRPO style reinforcement learning using [SkyRL](https://github.com/NovaSky-AI/SkyRL)
 
 ## 💿 Resources

--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -64,6 +64,7 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
     arch: str = "x86_64" if platform.machine() not in {"aarch64", "arm64"} else "arm64"
     pltf: str = "linux/x86_64" if arch == "x86_64" else "linux/arm64/v8"
     exts: list[str] = field(default_factory=lambda: SUPPORTED_EXTS)
+    eval_sets: set[str] = field(default_factory=set)
 
     # Install + Test specifications
     timeout: int = 90  # timeout (sec) for running test suite for a single instance

--- a/swesmith/profiles/c.py
+++ b/swesmith/profiles/c.py
@@ -1,6 +1,6 @@
 import re
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from swebench.harness.constants import TestStatus
 from swesmith.profiles.base import RepoProfile, registry
 
@@ -18,6 +18,9 @@ class Jqb9e19de76(CProfile):
     repo: str = "jq"
     commit: str = "b9e19de76e6e19d044007ead65d164710dc98877"
     test_cmd: str = "make check"
+    eval_sets: set[str] = field(
+        default_factory=lambda: {"SWE-bench/SWE-bench_Multilingual"}
+    )
 
     @property
     def dockerfile(self):
@@ -66,6 +69,9 @@ class Valkeyfc7c04e4(CProfile):
     repo: str = "valkey"
     commit: str = "fc7c04e4f8ba86dfbac1ec059db457fb44ed0a2d"
     test_cmd: str = "TERM=dumb ./runtest --durable"
+    eval_sets: set[str] = field(
+        default_factory=lambda: {"SWE-bench/SWE-bench_Multilingual"}
+    )
 
     @property
     def dockerfile(self):

--- a/swesmith/profiles/golang.py
+++ b/swesmith/profiles/golang.py
@@ -121,6 +121,9 @@ class Gin3c12d2a8(GoProfile):
     owner: str = "gin-gonic"
     repo: str = "gin"
     commit: str = "3c12d2a80e40930632fc4a4a4e1a45140f33fb12"
+    eval_sets: set[str] = field(
+        default_factory=lambda: {"SWE-bench/SWE-bench_Multilingual"}
+    )
 
 
 @dataclass
@@ -135,6 +138,9 @@ class Caddy77dd12cc(GoProfile):
     owner: str = "caddyserver"
     repo: str = "caddy"
     commit: str = "77dd12cc785990c5c5da947b4e883029ab8bd552"
+    eval_sets: set[str] = field(
+        default_factory=lambda: {"SWE-bench/SWE-bench_Multilingual"}
+    )
 
 
 @dataclass

--- a/swesmith/profiles/java.py
+++ b/swesmith/profiles/java.py
@@ -1,6 +1,6 @@
 import re
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from swebench.harness.constants import TestStatus
 from swesmith.profiles.base import RepoProfile, registry
 
@@ -18,6 +18,9 @@ class Gsondd2fe59c(JavaProfile):
     repo: str = "gson"
     commit: str = "dd2fe59c0d3390b2ad3dd365ed6938a5c15844cb"
     test_cmd: str = "mvn test -B -T 1C -Dsurefire.useFile=false -Dsurefire.printSummary=true -Dsurefire.reportFormat=plain"
+    eval_sets: set[str] = field(
+        default_factory=lambda: {"SWE-bench/SWE-bench_Multilingual"}
+    )
 
     @property
     def dockerfile(self):

--- a/swesmith/profiles/javascript.py
+++ b/swesmith/profiles/javascript.py
@@ -1,6 +1,6 @@
 import re
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from swesmith.constants import KEY_PATCH
 from swebench.harness.constants import TestStatus
 from swesmith.profiles.base import RepoProfile, registry
@@ -160,6 +160,9 @@ class Babel2ea3fc8f(JavaScriptProfile):
     repo: str = "babel"
     commit: str = "2ea3fc8f9b33a911840f17fbc407e7bfae2ed66f"
     test_cmd: str = "yarn jest --verbose"
+    eval_sets: set[str] = field(
+        default_factory=lambda: {"SWE-bench/SWE-bench_Multilingual"}
+    )
 
     @property
     def dockerfile(self):
@@ -221,6 +224,9 @@ class Axiosef36347f(JavaScriptProfile):
     repo: str = "axios"
     commit: str = "ef36347fb559383b04c755b07f1a8d11897fab7f"  # Replace with a specific commit hash
     test_cmd: str = "npm run test:mocha -- --verbose"
+    eval_sets: set[str] = field(
+        default_factory=lambda: {"SWE-bench/SWE-bench_Multilingual"}
+    )
 
     @property
     def dockerfile(self):

--- a/swesmith/profiles/python.py
+++ b/swesmith/profiles/python.py
@@ -352,6 +352,7 @@ class FlaskBc098406(PythonProfile):
     owner: str = "pallets"
     repo: str = "flask"
     commit: str = "bc098406af9537aacc436cb2ea777fbc9ff4c5aa"
+    eval_sets: set[str] = field(default_factory=lambda: {"SWE-bench/SWE-bench"})
 
 
 @dataclass
@@ -968,6 +969,7 @@ class Sympy2ab64612(PythonProfile):
     commit: str = "2ab64612efb287f09822419f4127878a4b664f71"
     min_testing: bool = True
     min_pregold: bool = True
+    eval_sets: set[str] = field(default_factory=lambda: {"SWE-bench/SWE-bench"})
 
 
 @dataclass

--- a/swesmith/profiles/python.py
+++ b/swesmith/profiles/python.py
@@ -352,7 +352,13 @@ class FlaskBc098406(PythonProfile):
     owner: str = "pallets"
     repo: str = "flask"
     commit: str = "bc098406af9537aacc436cb2ea777fbc9ff4c5aa"
-    eval_sets: set[str] = field(default_factory=lambda: {"SWE-bench/SWE-bench"})
+    eval_sets: set[str] = field(
+        default_factory=lambda: {
+            "SWE-bench/SWE-bench",
+            "SWE-bench/SWE-bench_Lite",
+            "SWE-bench/SWE-bench_Verified",
+        }
+    )
 
 
 @dataclass
@@ -969,7 +975,13 @@ class Sympy2ab64612(PythonProfile):
     commit: str = "2ab64612efb287f09822419f4127878a4b664f71"
     min_testing: bool = True
     min_pregold: bool = True
-    eval_sets: set[str] = field(default_factory=lambda: {"SWE-bench/SWE-bench"})
+    eval_sets: set[str] = field(
+        default_factory=lambda: {
+            "SWE-bench/SWE-bench",
+            "SWE-bench/SWE-bench_Lite",
+            "SWE-bench/SWE-bench_Verified",
+        }
+    )
 
 
 @dataclass

--- a/swesmith/profiles/rust.py
+++ b/swesmith/profiles/rust.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from swebench.harness.constants import TestStatus
 from swesmith.profiles.base import RepoProfile, registry
@@ -105,6 +105,9 @@ class Tokioab3ff69c(RustProfile):
     commit: str = "ab3ff69cf2258a8c696b2dca89a2cef4ff114c1c"
     test_cmd: str = "cargo test --verbose --features full -- --skip try_exists"
     timeout: int = 180
+    eval_sets: set[str] = field(
+        default_factory=lambda: {"SWE-bench/SWE-bench_Multilingual"}
+    )
 
 
 @dataclass


### PR DESCRIPTION
An alternative to the fixes proposed in #134.

I think the original PR makes a lot of sense, but with the proliferation of SWE-bench style datasets (e.g. SWE-bench Lite/Verified/Multimodal/Multilingual/Live, Multi-SWE-bench), excluding repos that are part of any evaluation set I think could be annoying for 2 reasons:
1. We'd have to track inclusion manually, with no convenient way to bookkeep which repos are / aren't part of eval sets. Especially as we scale up, this could get annoying.
2. With some eval sets being disjoint from one another (e.g. SWE-bench Multilingual vs. Multi-SWE-bench), we could be losing out on a couple repos that are "ok" to train on for one eval, but not the other.

Instead of removing these repos, this PR adds an `eval_sets` field that allows one to specify which benchmark(s) a repo is part of.