### PR TITLE
Fix Go line shuffling procedural modification

### DIFF
--- a/swesmith/bug_gen/procedural/golang/control_flow.py
+++ b/swesmith/bug_gen/procedural/golang/control_flow.py
@@ -179,14 +179,13 @@ class ControlShuffleLinesModifier(GolangProceduralModifier):
                     # Get the statements inside the block (excluding braces)
                     statements = []
                     for child in body_block.children:
-                        # Skip opening and closing braces, collect actual statements
-                        if child.type not in ["{", "}"]:
-                            statements.append(child)
-
-                    # Debug: Print the number of statements found
-                    # print(f"DEBUG: Found {len(statements)} statements in function/method")
-                    # for i, stmt in enumerate(statements):
-                    #     print(f"  Statement {i}: {stmt.type}")
+                        candidate_stmts = [child]
+                        if child.type == "statement_list":
+                            candidate_stmts = child.children
+                        for stmt in candidate_stmts:
+                            # Skip opening and closing braces, collect actual statements
+                            if stmt.type not in ["{", "}"]:
+                                statements.append(stmt)
 
                     # Only shuffle if there are at least 2 statements
                     if len(statements) >= 2:


### PR DESCRIPTION
Fixes #152

- tree-sitter-go v0.25.0 introduces a new statement_list intermediate AST node.
- This breaks the Go ControlShuffleLinesModifier because it expects to find the function statements directly underneath the function body.
- Update the modifier so that it handles the statement_list when present.

I removed the nearby commented debug lines as they didn't seem necessary.
