### PR TITLE
Drop unsupported model params

### DIFF
--- a/swesmith/bug_gen/llm/rewrite.py
+++ b/swesmith/bug_gen/llm/rewrite.py
@@ -50,6 +50,7 @@ from typing import Any
 LM_REWRITE = "lm_rewrite"
 
 logging.getLogger("LiteLLM").setLevel(logging.WARNING)
+litellm.drop_params = True
 litellm.suppress_debug_info = True
 random.seed(24)
 

--- a/swesmith/issue_gen/generate.py
+++ b/swesmith/issue_gen/generate.py
@@ -48,6 +48,7 @@ from swesmith.issue_gen.utils import get_test_function
 from swesmith.profiles import registry
 
 logging.getLogger("LiteLLM").setLevel(logging.WARNING)
+litellm.drop_params = True
 litellm.suppress_debug_info = True
 
 

--- a/swesmith/issue_gen/get_from_tests.py
+++ b/swesmith/issue_gen/get_from_tests.py
@@ -42,6 +42,7 @@ from swesmith.profiles.python import PythonProfile
 from tqdm.auto import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
+litellm.drop_params = True
 litellm.suppress_debug_info = True
 
 LOG_FILE_ISSUE = "issue_test.txt"


### PR DESCRIPTION
- Attempts to use gpt-5 models with certain commands would fail previously due to temperature not being supported
- Set litellm.drop_params to drop parameters not supported by models

Fixes:

> litellm.exceptions.UnsupportedParamsError: litellm.UnsupportedParamsError: gpt-5 models don't support temperature=0. Only temperature=1 is supported. To drop unsupported params set `litellm.drop_params = True`