### PR TITLE
Extract common build_entity function

### DIFF
--- a/swesmith/bug_gen/adapters/c.py
+++ b/swesmith/bug_gen/adapters/c.py
@@ -3,6 +3,7 @@ import tree_sitter_c as tsc
 
 from swesmith.constants import TODO_REWRITE, CodeEntity
 from tree_sitter import Language, Parser, Query, QueryCursor
+from .utils import build_entity
 
 C_LANGUAGE = Language(tsc.language())
 
@@ -71,7 +72,7 @@ def get_entities_from_file_c(
         # generates them parsing valid pre-processor directives
 
         if node.type == "function_definition":
-            entities.append(_build_entity(node, lines, file_path))
+            entities.append(build_entity(node, lines, file_path, CEntity))
             if 0 <= max_entities == len(entities):
                 return
 
@@ -79,41 +80,3 @@ def get_entities_from_file_c(
             walk(child)
 
     walk(root)
-
-
-def _build_entity(node, lines, file_path: str) -> CEntity:
-    """
-    Turns a Tree-sitter node into a CEntity object.
-    """
-    # start_point/end_point are (row, col) zero-based
-    start_row, _ = node.start_point
-    end_row, _ = node.end_point
-
-    # slice out the raw lines
-    snippet = lines[start_row : end_row + 1]
-
-    # detect indent on first line
-    first = snippet[0]
-    m = re.match(r"^(?P<indent>[\t ]*)", first)
-    indent_str = m.group("indent")
-    # tabs count as size=1, else use count of spaces, fallback to 4
-    indent_size = 1 if "\t" in indent_str else (len(indent_str) or 4)
-    indent_level = len(indent_str) // indent_size
-
-    # dedent each line
-    dedented = []
-    for line in snippet:
-        if len(line) >= indent_level * indent_size:
-            dedented.append(line[indent_level * indent_size :])
-        else:
-            dedented.append(line.lstrip("\t "))
-
-    return CEntity(
-        file_path=file_path,
-        indent_level=indent_level,
-        indent_size=indent_size,
-        line_start=start_row + 1,
-        line_end=end_row + 1,
-        node=node,
-        src_code="\n".join(dedented),
-    )

--- a/swesmith/bug_gen/adapters/c_sharp.py
+++ b/swesmith/bug_gen/adapters/c_sharp.py
@@ -4,6 +4,7 @@ import warnings
 from swesmith.constants import CodeEntity, TODO_REWRITE
 from tree_sitter import Language, Parser, Query, QueryCursor
 import tree_sitter_c_sharp as tscs
+from .utils import build_entity
 
 C_SHARP_LANGUAGE = Language(tscs.language())
 
@@ -99,7 +100,7 @@ def get_entities_from_file_c_sharp(
             if node.type == "method_declaration" and not _has_body(node):
                 pass
             else:
-                entities.append(_build_entity(node, lines, file_path))
+                entities.append(build_entity(node, lines, file_path, CSharpEntity))
                 if 0 <= max_entities == len(entities):
                     return
 
@@ -117,41 +118,3 @@ def _has_body(node) -> bool:
         if child.type == "block":
             return True
     return False
-
-
-def _build_entity(node, lines, file_path: str) -> CSharpEntity:
-    """
-    Turn a Tree-sitter node into CSharpEntity.
-    """
-    # start_point/end_point are (row, col) zero-based
-    start_row, _ = node.start_point
-    end_row, _ = node.end_point
-
-    # slice out the raw lines
-    snippet = lines[start_row : end_row + 1]
-
-    # detect indent on first line
-    first = snippet[0]
-    m = re.match(r"^(?P<indent>[\t ]*)", first)
-    indent_str = m.group("indent")
-    # tabs count as size=1, else use count of spaces, fallback to 4
-    indent_size = 1 if "\t" in indent_str else (len(indent_str) or 4)
-    indent_level = len(indent_str) // indent_size
-
-    # dedent each line
-    dedented = []
-    for line in snippet:
-        if len(line) >= indent_level * indent_size:
-            dedented.append(line[indent_level * indent_size :])
-        else:
-            dedented.append(line.lstrip("\t "))
-
-    return CSharpEntity(
-        file_path=file_path,
-        indent_level=indent_level,
-        indent_size=indent_size,
-        line_start=start_row + 1,
-        line_end=end_row + 1,
-        node=node,
-        src_code="\n".join(dedented),
-    )

--- a/swesmith/bug_gen/adapters/cpp.py
+++ b/swesmith/bug_gen/adapters/cpp.py
@@ -3,6 +3,7 @@ import tree_sitter_cpp as tscpp
 
 from swesmith.constants import TODO_REWRITE, CodeEntity
 from tree_sitter import Language, Parser, Query, QueryCursor
+from .utils import build_entity
 
 CPP_LANGUAGE = Language(tscpp.language())
 
@@ -74,7 +75,7 @@ def get_entities_from_file_cpp(
         # generates them parsing valid pre-processor directives
 
         if node.type == "function_definition":
-            entities.append(_build_entity(node, lines, file_path))
+            entities.append(build_entity(node, lines, file_path, CPlusPlusEntity))
             if 0 <= max_entities == len(entities):
                 return
 
@@ -82,41 +83,3 @@ def get_entities_from_file_cpp(
             walk(child)
 
     walk(root)
-
-
-def _build_entity(node, lines, file_path: str) -> CPlusPlusEntity:
-    """
-    Turns a Tree-sitter node into a CPlusPlusEntity object.
-    """
-    # start_point/end_point are (row, col) zero-based
-    start_row, _ = node.start_point
-    end_row, _ = node.end_point
-
-    # slice out the raw lines
-    snippet = lines[start_row : end_row + 1]
-
-    # detect indent on first line
-    first = snippet[0]
-    m = re.match(r"^(?P<indent>[\t ]*)", first)
-    indent_str = m.group("indent")
-    # tabs count as size=1, else use count of spaces, fallback to 4
-    indent_size = 1 if "\t" in indent_str else (len(indent_str) or 4)
-    indent_level = len(indent_str) // indent_size
-
-    # dedent each line
-    dedented = []
-    for line in snippet:
-        if len(line) >= indent_level * indent_size:
-            dedented.append(line[indent_level * indent_size :])
-        else:
-            dedented.append(line.lstrip("\t "))
-
-    return CPlusPlusEntity(
-        file_path=file_path,
-        indent_level=indent_level,
-        indent_size=indent_size,
-        line_start=start_row + 1,
-        line_end=end_row + 1,
-        node=node,
-        src_code="\n".join(dedented),
-    )

--- a/swesmith/bug_gen/adapters/golang.py
+++ b/swesmith/bug_gen/adapters/golang.py
@@ -1,9 +1,8 @@
-import re
-
 from swesmith.constants import TODO_REWRITE, CodeEntity, CodeProperty
 from tree_sitter import Language, Parser, Query, QueryCursor
 import tree_sitter_go as tsgo
 import warnings
+from .utils import build_entity
 
 GO_LANGUAGE = Language(tsgo.language())
 
@@ -206,7 +205,7 @@ def get_entities_from_file_go(
             "function_declaration",
             "method_declaration",
         ]:
-            entities.append(_build_entity(node, lines, file_path))
+            entities.append(build_entity(node, lines, file_path, GoEntity))
             if 0 <= max_entities == len(entities):
                 return
 
@@ -214,41 +213,3 @@ def get_entities_from_file_go(
             walk(child)
 
     walk(root)
-
-
-def _build_entity(node, lines, file_path: str) -> GoEntity:
-    """
-    Turns a Tree-sitter node into a GoEntity object.
-    """
-    # start_point/end_point are (row, col) zero-based
-    start_row, _ = node.start_point
-    end_row, _ = node.end_point
-
-    # slice out the raw lines
-    snippet = lines[start_row : end_row + 1]
-
-    # detect indent on first line
-    first = snippet[0]
-    m = re.match(r"^(?P<indent>[\t ]*)", first)
-    indent_str = m.group("indent")
-    # tabs count as size=1, else use count of spaces, fallback to 4
-    indent_size = 1 if "\t" in indent_str else (len(indent_str) or 4)
-    indent_level = len(indent_str) // indent_size
-
-    # dedent each line
-    dedented = []
-    for line in snippet:
-        if len(line) >= indent_level * indent_size:
-            dedented.append(line[indent_level * indent_size :])
-        else:
-            dedented.append(line.lstrip("\t "))
-
-    return GoEntity(
-        file_path=file_path,
-        indent_level=indent_level,
-        indent_size=indent_size,
-        line_start=start_row + 1,
-        line_end=end_row + 1,
-        node=node,
-        src_code="\n".join(dedented),
-    )

--- a/swesmith/bug_gen/adapters/java.py
+++ b/swesmith/bug_gen/adapters/java.py
@@ -4,6 +4,7 @@ import warnings
 from swesmith.constants import CodeEntity, TODO_REWRITE
 from tree_sitter import Language, Parser, Query, QueryCursor
 import tree_sitter_java as tsjava
+from .utils import build_entity
 
 JAVA_LANGUAGE = Language(tsjava.language())
 
@@ -92,7 +93,7 @@ def get_entities_from_file_java(
             if node.type == "method_declaration" and not _has_body(node):
                 pass
             else:
-                entities.append(_build_entity(node, lines, file_path))
+                entities.append(build_entity(node, lines, file_path, JavaEntity))
                 if 0 <= max_entities == len(entities):
                     return
 
@@ -110,41 +111,3 @@ def _has_body(node) -> bool:
         if child.type == "block":
             return True
     return False
-
-
-def _build_entity(node, lines, file_path: str) -> JavaEntity:
-    """
-    Turns a Tree-sitter node into a JavaEntity object.
-    """
-    # start_point/end_point are (row, col) zero-based
-    start_row, _ = node.start_point
-    end_row, _ = node.end_point
-
-    # slice out the raw lines
-    snippet = lines[start_row : end_row + 1]
-
-    # detect indent on first line
-    first = snippet[0]
-    m = re.match(r"^(?P<indent>[\t ]*)", first)
-    indent_str = m.group("indent")
-    # tabs count as size=1, else use count of spaces, fallback to 4
-    indent_size = 1 if "\t" in indent_str else (len(indent_str) or 4)
-    indent_level = len(indent_str) // indent_size
-
-    # dedent each line
-    dedented = []
-    for line in snippet:
-        if len(line) >= indent_level * indent_size:
-            dedented.append(line[indent_level * indent_size :])
-        else:
-            dedented.append(line.lstrip("\t "))
-
-    return JavaEntity(
-        file_path=file_path,
-        indent_level=indent_level,
-        indent_size=indent_size,
-        line_start=start_row + 1,
-        line_end=end_row + 1,
-        node=node,
-        src_code="\n".join(dedented),
-    )

--- a/swesmith/bug_gen/adapters/javascript.py
+++ b/swesmith/bug_gen/adapters/javascript.py
@@ -1,10 +1,10 @@
-import re
 import warnings
 
 import tree_sitter_javascript as tsjs
 
 from swesmith.constants import CodeEntity, CodeProperty, TODO_REWRITE
 from tree_sitter import Language, Parser
+from .utils import build_entity
 
 JS_LANGUAGE = Language(tsjs.language())
 
@@ -264,7 +264,11 @@ def _walk_and_collect(node, entities, lines, file_path, max_entities):
         "method_definition",
         "class_declaration",
     ]:
-        entities.append(_build_entity(node, lines, file_path))
+        entities.append(
+            build_entity(
+                node, lines, file_path, JavaScriptEntity, default_indent_size=2
+            )
+        )
         if 0 <= max_entities == len(entities):
             return
 
@@ -286,7 +290,15 @@ def _collect_variable_functions(node, entities, lines, file_path, max_entities):
         if child.type == "variable_declarator":
             for grandchild in child.children:
                 if grandchild.type in ["function_expression", "arrow_function"]:
-                    entities.append(_build_entity(child, lines, file_path))
+                    entities.append(
+                        build_entity(
+                            child,
+                            lines,
+                            file_path,
+                            JavaScriptEntity,
+                            default_indent_size=2,
+                        )
+                    )
                     if 0 <= max_entities == len(entities):
                         return
 
@@ -295,44 +307,10 @@ def _collect_assignment_functions(node, entities, lines, file_path, max_entities
     """Collect function expressions from assignment expressions."""
     for child in node.children:
         if child.type in ["function_expression", "arrow_function"]:
-            entities.append(_build_entity(node, lines, file_path))
+            entities.append(
+                build_entity(
+                    node, lines, file_path, JavaScriptEntity, default_indent_size=2
+                )
+            )
             if 0 <= max_entities == len(entities):
                 return
-
-
-def _build_entity(node, lines, file_path: str) -> JavaScriptEntity:
-    """
-    Turn a Tree-sitter node into JavaScriptEntity.
-    """
-    # start_point/end_point are (row, col) zero-based
-    start_row, _ = node.start_point
-    end_row, _ = node.end_point
-
-    # slice out the raw lines
-    snippet = lines[start_row : end_row + 1]
-
-    # detect indent on first line
-    first = snippet[0]
-    m = re.match(r"^(?P<indent>[\t ]*)", first)
-    indent_str = m.group("indent") if m else ""
-    # tabs count as size=1, else use count of spaces, fallback to 2 (common in JS)
-    indent_size = 1 if "\t" in indent_str else (len(indent_str) or 2)
-    indent_level = len(indent_str) // indent_size
-
-    # dedent each line
-    dedented = []
-    for line in snippet:
-        if len(line) >= indent_level * indent_size:
-            dedented.append(line[indent_level * indent_size :])
-        else:
-            dedented.append(line.lstrip("\t "))
-
-    return JavaScriptEntity(
-        file_path=file_path,
-        indent_level=indent_level,
-        indent_size=indent_size,
-        line_start=start_row + 1,
-        line_end=end_row + 1,
-        node=node,
-        src_code="\n".join(dedented),
-    )

--- a/swesmith/bug_gen/adapters/php.py
+++ b/swesmith/bug_gen/adapters/php.py
@@ -3,6 +3,7 @@ import re
 from swesmith.constants import TODO_REWRITE, CodeEntity
 from tree_sitter import Language, Parser
 import tree_sitter_php as tsphp
+from .utils import build_entity
 
 PHP_LANGUAGE = Language(tsphp.language_php())
 
@@ -92,7 +93,7 @@ def get_entities_from_file_php(
                 "method_declaration",
                 "class_declaration",
             ]:
-                entities.append(_build_entity(node, lines, file_path))
+                entities.append(build_entity(node, lines, file_path, PhpEntity))
                 if 0 <= max_entities == len(entities):
                     return
 
@@ -103,41 +104,3 @@ def get_entities_from_file_php(
         return entities
     except Exception:
         return entities
-
-
-def _build_entity(node, lines, file_path: str) -> PhpEntity:
-    """
-    Turn a Tree-sitter node into PhpEntity.
-    """
-    # start_point/end_point are (row, col) zero-based
-    start_row, _ = node.start_point
-    end_row, _ = node.end_point
-
-    # slice out the raw lines
-    snippet = lines[start_row : end_row + 1]
-
-    # detect indent on first line
-    first = snippet[0] if snippet else ""
-    m = re.match(r"^(?P<indent>[\t ]*)", first)
-    indent_str = m.group("indent") if m else ""
-    # tabs count as size=1, else use count of spaces, fallback to 4
-    indent_size = 1 if "\t" in indent_str else (len(indent_str) or 4)
-    indent_level = len(indent_str) // indent_size
-
-    # dedent each line
-    dedented = []
-    for line in snippet:
-        if len(line) >= indent_level * indent_size:
-            dedented.append(line[indent_level * indent_size :])
-        else:
-            dedented.append(line.lstrip("\t "))
-
-    return PhpEntity(
-        file_path=file_path,
-        indent_level=indent_level,
-        indent_size=indent_size,
-        line_start=start_row + 1,
-        line_end=end_row + 1,
-        node=node,
-        src_code="\n".join(dedented),
-    )

--- a/swesmith/bug_gen/adapters/ruby.py
+++ b/swesmith/bug_gen/adapters/ruby.py
@@ -1,9 +1,8 @@
-import re
-
 from swesmith.constants import TODO_REWRITE, CodeEntity
 from tree_sitter import Language, Parser, Query, QueryCursor
 import tree_sitter_ruby as tsr
 import warnings
+from .utils import build_entity
 
 RUBY_LANGUAGE = Language(tsr.language())
 
@@ -133,7 +132,7 @@ def get_entities_from_file_rb(
             "singleton_method",
         ]:
             if any(child.type == "body_statement" for child in node.children):
-                entities.append(_build_entity(node, lines, file_path))
+                entities.append(build_entity(node, lines, file_path, RubyEntity))
                 if 0 <= max_entities == len(entities):
                     return
 
@@ -141,41 +140,3 @@ def get_entities_from_file_rb(
             walk(child)
 
     walk(root)
-
-
-def _build_entity(node, lines, file_path: str) -> RubyEntity:
-    """
-    Turns a Tree-sitter node into a RubyEntity object.
-    """
-    # start_point/end_point are (row, col) zero-based
-    start_row, _ = node.start_point
-    end_row, _ = node.end_point
-
-    # slice out the raw lines
-    snippet = lines[start_row : end_row + 1]
-
-    # detect indent on first line
-    first = snippet[0]
-    m = re.match(r"^(?P<indent>[\t ]*)", first)
-    indent_str = m.group("indent")
-    # tabs count as size=1, else use count of spaces, fallback to 4
-    indent_size = 1 if "\t" in indent_str else (len(indent_str) or 4)
-    indent_level = len(indent_str) // indent_size
-
-    # dedent each line
-    dedented = []
-    for line in snippet:
-        if len(line) >= indent_level * indent_size:
-            dedented.append(line[indent_level * indent_size :])
-        else:
-            dedented.append(line.lstrip("\t "))
-
-    return RubyEntity(
-        file_path=file_path,
-        indent_level=indent_level,
-        indent_size=indent_size,
-        line_start=start_row + 1,
-        line_end=end_row + 1,
-        node=node,
-        src_code="\n".join(dedented),
-    )

--- a/swesmith/bug_gen/adapters/rust.py
+++ b/swesmith/bug_gen/adapters/rust.py
@@ -4,6 +4,7 @@ import warnings
 
 from swesmith.constants import TODO_REWRITE, CodeEntity
 from tree_sitter import Language, Parser, Query, QueryCursor
+from .utils import build_entity
 
 RUST_LANGUAGE = Language(tsrs.language())
 
@@ -71,7 +72,7 @@ def get_entities_from_file_rs(
             if _has_test_attribute(node):
                 return
 
-            entities.append(_build_entity(node, lines, file_path))
+            entities.append(build_entity(node, lines, file_path, RustEntity))
             if 0 <= max_entities == len(entities):
                 return
 
@@ -88,41 +89,3 @@ def _has_test_attribute(node) -> bool:
             return True
         possible_att = possible_att.prev_named_sibling
     return False
-
-
-def _build_entity(node, lines, file_path: str) -> RustEntity:
-    """
-    Turns a Tree-sitter node into a RustEntity object.
-    """
-    # start_point/end_point are (row, col) zero-based
-    start_row, _ = node.start_point
-    end_row, _ = node.end_point
-
-    # slice out the raw lines
-    snippet = lines[start_row : end_row + 1]
-
-    # detect indent on first line
-    first = snippet[0]
-    m = re.match(r"^(?P<indent>[\t ]*)", first)
-    indent_str = m.group("indent")
-    # tabs count as size=1, else use count of spaces, fallback to 4
-    indent_size = 1 if "\t" in indent_str else (len(indent_str) or 4)
-    indent_level = len(indent_str) // indent_size
-
-    # dedent each line
-    dedented = []
-    for line in snippet:
-        if len(line) >= indent_level * indent_size:
-            dedented.append(line[indent_level * indent_size :])
-        else:
-            dedented.append(line.lstrip("\t "))
-
-    return RustEntity(
-        file_path=file_path,
-        indent_level=indent_level,
-        indent_size=indent_size,
-        line_start=start_row + 1,
-        line_end=end_row + 1,
-        node=node,
-        src_code="\n".join(dedented),
-    )

--- a/swesmith/bug_gen/adapters/utils.py
+++ b/swesmith/bug_gen/adapters/utils.py
@@ -1,0 +1,53 @@
+"""
+Utility functions for language adapters.
+"""
+
+import re
+from typing import TypeVar, Type
+from swesmith.constants import CodeEntity
+
+T = TypeVar("T", bound=CodeEntity)
+
+
+def build_entity(
+    node,
+    lines: list[str],
+    file_path: str,
+    entity_class: Type[T],
+    default_indent_size: int = 4,
+) -> T:
+    """
+    Turns a Tree-sitter node into a CodeEntity object.
+    """
+    # start_point/end_point are (row, col) zero-based
+    start_row, _ = node.start_point
+    end_row, _ = node.end_point
+
+    # slice out the raw lines
+    snippet = lines[start_row : end_row + 1]
+
+    # detect indent on first line
+    first = snippet[0] if snippet else ""
+    m = re.match(r"^(?P<indent>[\t ]*)", first)
+    indent_str = m.group("indent") if m else ""
+    # tabs count as size=1, else use count of spaces, fallback to default_indent_size
+    indent_size = 1 if "\t" in indent_str else (len(indent_str) or default_indent_size)
+    indent_level = len(indent_str) // indent_size
+
+    # dedent each line
+    dedented = []
+    for line in snippet:
+        if len(line) >= indent_level * indent_size:
+            dedented.append(line[indent_level * indent_size :])
+        else:
+            dedented.append(line.lstrip("\t "))
+
+    return entity_class(
+        file_path=file_path,
+        indent_level=indent_level,
+        indent_size=indent_size,
+        line_start=start_row + 1,
+        line_end=end_row + 1,
+        node=node,
+        src_code="\n".join(dedented),
+    )


### PR DESCRIPTION
- Remove duplication by extracting `_build_entity` helper functions in tree-sitter based language adapters to a shared function.
- Preserve existing default indent size differences between the adapters, I've not thought about these defaults.