### PR TITLE
Docs: add Tutorials landing page with overview and navigation

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,1 +1,91 @@
 # Tutorials
+
+Build unlimited training data and train state-of-the-art SWE-agents. This guide covers the complete workflow: from environment setup to model training and evaluation.
+
+---
+
+## 📋 Prerequisites
+
+!!! info "System Requirements"
+    **Required:** Docker
+    **Tested on:** Ubuntu 22.04.4 LTS
+    **Not supported:** Windows, macOS
+
+New to SWE-smith? Start with [Installation](../getting_started/installation.md) and [Quickstart](../getting_started/quickstart.md).
+
+---
+
+## 🎯 Quick Navigation
+
+<div class="grid cards" markdown>
+
+-   :material-docker: **Build Environments**
+
+    ---
+
+    Create reproducible Docker images for any repository. Capture dependencies, build containers, and validate with automated testing.
+
+    [:octicons-arrow-right-24: Get started](env_construction.md)
+
+-   :material-bug: **Create Instances**
+
+    ---
+
+    Generate task instances using LM prompts, procedural modifications, PR mirroring, or combined techniques. Scale to thousands of bugs.
+
+    [:octicons-arrow-right-24: Generate bugs](create_instances.md)
+
+-   :material-check-circle: **Validate & Evaluate**
+
+    ---
+
+    Filter candidates that break tests and verify proposed solutions. Built-in harnesses for validation and evaluation workflows.
+
+    [:octicons-arrow-right-24: Run harnesses](harnesses.md)
+
+-   :material-file-document: **Generate Issue Text**
+
+    ---
+
+    Add natural language problem statements to task instances using LM generation or alternative methods.
+
+    [:octicons-arrow-right-24: Create issues](issue_gen.md)
+
+-   :material-speedometer: **Rate Difficulty** · Optional
+
+    ---
+
+    Classify tasks as easy/medium/hard using a fine-tuned Qwen 2.5 Coder model. Compare against SWE-bench benchmarks.
+
+    [:octicons-arrow-right-24: Assess difficulty](difficulty_rating.md)
+
+-   :material-school: **Train SWE-agents**
+
+    ---
+
+    Complete RSFT pipeline: generate trajectories, filter successful solutions, fine-tune models, and evaluate on SWE-bench.
+
+    [:octicons-arrow-right-24: Start training](train_swe_agent.md)
+
+</div>
+
+---
+
+##  Recommended Workflow
+
+```mermaid
+graph LR
+    A[Build Environments] --> B[Create Instances]
+    B --> C[Validate & Evaluate]
+    C --> D[Generate Issue Text]
+    D --> E[Rate Difficulty]
+    D --> F[Train SWE-agents]
+    E --> F
+```
+
+1. **Build Environments** → Set up Docker images
+2. **Create Instances** → Generate synthetic bugs
+3. **Validate & Evaluate** → Filter valid task instances
+4. **Generate Issue Text** → Add problem descriptions
+5. **Rate Difficulty** *(optional)* → Classify task complexity
+6. **Train SWE-agents** → Fine-tune models with RSFT

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,11 @@ markdown_extensions:
   - sane_lists
   - admonition
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.magiclink
   - footnotes
   - attr_list


### PR DESCRIPTION
   ## Summary
   Adds an overview to `/guides/index.md` addressing Issue #169.

   ## Details
   - ✅ **Introduction**: Brief summary of the complete workflow
   - ✅ **Prerequisites section**: Docker + Ubuntu 22.04.4 LTS requirements with info admonition
   - ✅ **Grid cards navigation**: Clean Material for MkDocs cards linking to all 6 tutorials
   - ✅ **Workflow diagram**: Mermaid diagram showing the recommended path
   - ✅ **Concise summaries**: Brief descriptions for each tutorial section

   ## Additional Changes
   - Updated `mkdocs.yml` to enable Mermaid diagram support (`pymdownx.superfences` custom fences)

   Closes #169

  Let me know if you'd like any changes to the content or structure.