### PR TITLE
Fix container name conflict in get_container() for parallel execution

### DIFF
--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -315,6 +315,7 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
     def get_container(self, instance: dict) -> Container:
         """Return a docker container with the task instance initialized"""
         import uuid
+
         client = docker.from_env()
         self.pull_image()
         instance_id = instance[KEY_INSTANCE_ID]


### PR DESCRIPTION
Hi! This project is amazing, thanks for the contribution! I found a bug when I run the worker in parallel, hope this can help.

## Problem

When using Ray or other parallel execution frameworks to run multiple containers for the same `instance_id`, the current implementation of `RepoProfile.get_container()` causes **container name conflicts**.

### Root Cause

In `swesmith/profiles/base.py`, the `get_container()` method uses `instance_id` directly as both:
1. The Docker container name
2. The git branch name for checkout

```python
# Before (problematic code)
def get_container(self, instance: dict) -> Container:
    container = client.containers.create(
        name=instance[KEY_INSTANCE_ID],  # ❌ Container name = instance_id
        ...
    )
    val = container.exec_run(
        f"git checkout {instance[KEY_INSTANCE_ID]}",  # Branch name = instance_id
        ...
    )
```

### The Issue

When running in parallel (e.g., with Ray workers), if two workers try to create containers for the same `instance_id`:
- Docker raises: `Conflict. The container name "xxx" is already in use`

## Solution

Auto-generate a unique UUID suffix for container names while keeping git checkout unchanged:

```python
# After (fixed code)
def get_container(self, instance: dict) -> Container:
    import uuid
    instance_id = instance[KEY_INSTANCE_ID]
    # Use unique suffix to avoid container name conflicts in parallel execution
    container_name = f"{instance_id}.{uuid.uuid4().hex[:8]}"
    container = client.containers.create(
        name=container_name,  # ✅ Unique container name (e.g., "instance_id.a1b2c3d4")
        ...
    )
    val = container.exec_run(
        f"git checkout {instance_id}",  # ✅ Branch name unchanged
        ...
    )
```

## Key Points

1. **Minimal change**: No interface changes, no new parameters
2. **Backward compatible**: All existing code works without modification
3. **Decouples container name from branch name**: Container name is unique, git checkout still uses `instance_id`

## Related Code

Note that `swesmith/harness/utils.py` already handles this correctly by using a unique container name format:
```python
container_name = f"swesmith.{container_type}.{run_id}.{instance_id}"
```

This PR brings `get_container()` in line with that pattern.

## Testing

- [ ] Existing tests pass
- [ ] Tested with Ray parallel execution (no more container name conflicts)

## Checklist

- [x] Code follows project style guidelines
- [x] Minimal change, no interface modifications
- [x] Backward compatible
- [x] No breaking changes
