### PR TITLE
fix push_image with dynamic image existence tracking

### DIFF
--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -16,6 +16,7 @@ from collections import UserDict
 from dataclasses import dataclass, field
 from docker.models.containers import Container
 from dotenv import load_dotenv
+from functools import cached_property
 from ghapi.all import GhApi
 from multiprocessing import Lock
 from pathlib import Path
@@ -107,7 +108,7 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
     def image_name(self) -> str:
         return f"{self.org_dh}/swesmith.{self.arch}.{self.owner}_1776_{self.repo}.{self.commit[:8]}".lower()
 
-    @property
+    @cached_property
     def _cache_image_exists(self) -> bool:
         """Check if Docker image exists locally."""
         try:


### PR DESCRIPTION
### Background & Problem

Guide says, "run the following command to create a Docker image for the repository":
```
python -m swesmith.build_repo.create_images --repos MyOrg/MyRepo --push
```
where `--push` will invoke the `push_image` method. 

`create_images.py` code path:
```
main() 
  → build_all_images() 
    → executor.submit(build_profile_image, profile, push)
      → build_profile_image() [line 18-36]
        → profile.build_image() [line 30]  
        → profile.push_image() 
```

The `_cache_image_exists` attribute is always false for that workflow, so the `push_image` will always raise AssertionError here:
```
        assert self._cache_image_exists is True, (
            "Image must be built or pulled before pushing"
        )
```
even those the image was successfully built and is available locally:
```
$ cd /Users/danielzayas/Development/SWE-bench/SWE-smith && uv run python -m swesmith.build_repo.create_images --profiles danielzayas/swesmith.x86_64.python-openxml_1776_python-docx.0cf6d71f --push --proceed
Total profiles to build: 1
- danielzayas/swesmith.x86_64.python-openxml_1776_python-docx.0cf6d71f
Building environment images: 100%|██████████| 1/1 [01:22<00:00, 82.76s/it]NoneType: None

Error building danielzayas/swesmith.x86_64.python-openxml_1776_python-docx.0cf6d71f: Image must be built or pulled before pushing
1 environment images failed to build.
- Failed builds: ['danielzayas/swesmith.x86_64.python-openxml_1776_python-docx.0cf6d71f']
Building environment images: 100%|██████████| 1/1 [01:22<00:00, 82.77s/it]
```

### Proposed Change

One-line update to PythonProfile build_image to fix downstream push_image AssertionError. 

### Test Plan

The push now succeeds via the following command:
```
$ cd /Users/danielzayas/Development/SWE-bench/SWE-smith && uv run python -m swesmith.build_repo.create_images --profiles danielzayas/swesmith.x86_64.python-openxml_1776_python-docx.0cf6d71f --push --proceed
Using default tag: latest
The push refers to repository [docker.io/danielzayas/swesmith.x86_64.python-openxml_1776_python-docx.0cf6d71f]
...
18156425ea71: Pushed
latest: digest: sha256:4933f27b0a6e1b15bbb3690e6ae9b940c2d66a57022bd065d37477ce1e4078f6 size: 2964
All environment images built successfully.
- Successful builds: 1
Building environment images: 100%|██████████| 1/1 [01:49<00:00, 109.46s/it]
```
