### PR TITLE
fix(install_repo): fallback to whereis for conda discovery

### DIFF
--- a/configs/install_repo.sh
+++ b/configs/install_repo.sh
@@ -8,6 +8,8 @@ elif [ -f "/opt/miniconda3/bin/activate" ]; then
     . /opt/miniconda3/bin/activate
 elif [ -f "$HOME/miniconda3/bin/activate" ]; then
     . "$HOME/miniconda3/bin/activate"
+elif CONDA_BIN=$(whereis -b conda | awk '{print $2}') && [ -n "$CONDA_BIN" ]; then
+    . "$(dirname "$CONDA_BIN")/activate"
 else
     echo "Error: Could not find conda installation"
     exit 1


### PR DESCRIPTION
Add whereis-based conda lookup as a last resort for non-standard install paths.