### PR TITLE
Add PHP language support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .api_key
 
 # Folders
+.claude/
 hidden/
 logs/
 notebooks/

--- a/swesmith/bug_gen/adapters/php.py
+++ b/swesmith/bug_gen/adapters/php.py
@@ -89,7 +89,11 @@ class PhpEntity(CodeEntity):
         """Check for various operations."""
         if n.type in ["subscript_expression", "member_access_expression"]:
             self._tags.add(CodeProperty.HAS_LIST_INDEXING)
-        if n.type in ["function_call_expression", "member_call_expression", "scoped_call_expression"]:
+        if n.type in [
+            "function_call_expression",
+            "member_call_expression",
+            "scoped_call_expression",
+        ]:
             self._tags.add(CodeProperty.HAS_FUNCTION_CALL)
         if n.type == "return_statement":
             self._tags.add(CodeProperty.HAS_RETURN)

--- a/swesmith/bug_gen/adapters/php.py
+++ b/swesmith/bug_gen/adapters/php.py
@@ -103,7 +103,7 @@ class PhpEntity(CodeEntity):
             self._tags.add(CodeProperty.HAS_ASSIGNMENT)
         if n.type == "arrow_function":
             self._tags.add(CodeProperty.HAS_LAMBDA)
-        if n.type == "anonymous_function_creation_expression":
+        if n.type == "anonymous_function":
             self._tags.add(CodeProperty.HAS_LAMBDA)
         if n.type in ["binary_expression", "unary_op_expression", "update_expression"]:
             self._tags.add(CodeProperty.HAS_ARITHMETIC)

--- a/swesmith/bug_gen/adapters/php.py
+++ b/swesmith/bug_gen/adapters/php.py
@@ -1,6 +1,6 @@
 import re
 
-from swesmith.constants import TODO_REWRITE, CodeEntity
+from swesmith.constants import TODO_REWRITE, CodeEntity, CodeProperty
 from tree_sitter import Language, Parser
 import tree_sitter_php as tsphp
 from swesmith.bug_gen.adapters.utils import build_entity
@@ -46,6 +46,119 @@ class PhpEntity(CodeEntity):
             if child.type == "name":
                 return child.text.decode("utf-8")
         return None
+
+    def _analyze_properties(self):
+        """Analyze PHP code properties for procedural modifiers."""
+        node = self.node
+
+        # Core entity types
+        if node.type in ["function_definition", "method_declaration"]:
+            self._tags.add(CodeProperty.IS_FUNCTION)
+        elif node.type == "class_declaration":
+            self._tags.add(CodeProperty.IS_CLASS)
+
+        self._walk_for_properties(node)
+
+    def _walk_for_properties(self, n):
+        """Walk the AST and analyze properties."""
+        self._check_control_flow(n)
+        self._check_operations(n)
+        self._check_expressions(n)
+        for child in n.children:
+            self._walk_for_properties(child)
+
+    def _check_control_flow(self, n):
+        """Check for control flow patterns."""
+        if n.type in [
+            "for_statement",
+            "foreach_statement",
+            "while_statement",
+            "do_statement",
+        ]:
+            self._tags.add(CodeProperty.HAS_LOOP)
+        if n.type == "if_statement":
+            self._tags.add(CodeProperty.HAS_IF)
+            if any(child.type == "else_clause" for child in n.children):
+                self._tags.add(CodeProperty.HAS_IF_ELSE)
+        if n.type == "switch_statement":
+            self._tags.add(CodeProperty.HAS_SWITCH)
+        if n.type in ["try_statement", "catch_clause", "throw_expression"]:
+            self._tags.add(CodeProperty.HAS_EXCEPTION)
+
+    def _check_operations(self, n):
+        """Check for various operations."""
+        if n.type in ["subscript_expression", "member_access_expression"]:
+            self._tags.add(CodeProperty.HAS_LIST_INDEXING)
+        if n.type in ["function_call_expression", "member_call_expression", "scoped_call_expression"]:
+            self._tags.add(CodeProperty.HAS_FUNCTION_CALL)
+        if n.type == "return_statement":
+            self._tags.add(CodeProperty.HAS_RETURN)
+        if n.type in ["namespace_use_declaration"]:
+            self._tags.add(CodeProperty.HAS_IMPORT)
+        if n.type in ["assignment_expression", "augmented_assignment_expression"]:
+            self._tags.add(CodeProperty.HAS_ASSIGNMENT)
+        if n.type == "arrow_function":
+            self._tags.add(CodeProperty.HAS_LAMBDA)
+        if n.type == "anonymous_function_creation_expression":
+            self._tags.add(CodeProperty.HAS_LAMBDA)
+        if n.type in ["binary_expression", "unary_op_expression", "update_expression"]:
+            self._tags.add(CodeProperty.HAS_ARITHMETIC)
+        if n.type in ["try_statement"]:
+            self._tags.add(CodeProperty.HAS_WRAPPER)
+        if n.type == "class_declaration" and any(
+            child.type == "base_clause" for child in n.children
+        ):
+            self._tags.add(CodeProperty.HAS_PARENT)
+        if n.type in ["unary_op_expression", "update_expression"]:
+            self._tags.add(CodeProperty.HAS_UNARY_OP)
+        if n.type == "conditional_expression":
+            self._tags.add(CodeProperty.HAS_TERNARY)
+
+    def _check_expressions(self, n):
+        """Check binary expression patterns."""
+        if n.type == "binary_expression":
+            self._tags.add(CodeProperty.HAS_BINARY_OP)
+            for child in n.children:
+                if hasattr(child, "text"):
+                    text = child.text.decode("utf-8")
+                    if text in ["&&", "||", "and", "or"]:
+                        self._tags.add(CodeProperty.HAS_BOOL_OP)
+                    elif text in ["<", ">", "<=", ">="]:
+                        self._tags.add(CodeProperty.HAS_OFF_BY_ONE)
+
+    @property
+    def complexity(self) -> int:
+        """Calculate cyclomatic complexity for PHP code."""
+
+        def walk(node):
+            score = 0
+            if node.type in [
+                "if_statement",
+                "else_clause",
+                "for_statement",
+                "foreach_statement",
+                "while_statement",
+                "do_statement",
+                "switch_statement",
+                "case_statement",
+                "catch_clause",
+                "conditional_expression",
+            ]:
+                score += 1
+            if node.type == "binary_expression":
+                for child in node.children:
+                    if hasattr(child, "text") and child.text.decode("utf-8") in [
+                        "&&",
+                        "||",
+                        "and",
+                        "or",
+                    ]:
+                        score += 1
+            for child in node.children:
+                score += walk(child)
+            return score
+
+        return 1 + walk(self.node)
 
     @property
     def signature(self) -> str:

--- a/swesmith/bug_gen/procedural/__init__.py
+++ b/swesmith/bug_gen/procedural/__init__.py
@@ -11,6 +11,7 @@ from swesmith.bug_gen.procedural.cpp import MODIFIERS_CPP
 from swesmith.bug_gen.procedural.golang import MODIFIERS_GOLANG
 from swesmith.bug_gen.procedural.java import MODIFIERS_JAVA
 from swesmith.bug_gen.procedural.javascript import MODIFIERS_JAVASCRIPT
+from swesmith.bug_gen.procedural.php import MODIFIERS_PHP
 from swesmith.bug_gen.procedural.python import MODIFIERS_PYTHON
 from swesmith.bug_gen.procedural.rust import MODIFIERS_RUST
 from swesmith.bug_gen.procedural.typescript import MODIFIERS_TYPESCRIPT
@@ -24,6 +25,7 @@ MAP_EXT_TO_MODIFIERS = {
     ".h": MODIFIERS_CPP,
     ".hpp": MODIFIERS_CPP,
     ".js": MODIFIERS_JAVASCRIPT,
+    ".php": MODIFIERS_PHP,
     ".py": MODIFIERS_PYTHON,
     ".rs": MODIFIERS_RUST,
     ".ts": MODIFIERS_TYPESCRIPT,

--- a/swesmith/bug_gen/procedural/php/__init__.py
+++ b/swesmith/bug_gen/procedural/php/__init__.py
@@ -1,0 +1,12 @@
+"""
+PHP procedural modifiers for bug generation.
+
+PHP shares most tree-sitter node types with JavaScript (binary_expression,
+if_statement, for_statement, etc.), so we reuse the JavaScript modifiers.
+"""
+
+from swesmith.bug_gen.procedural.javascript import MODIFIERS_JAVASCRIPT
+
+# PHP uses the same tree-sitter AST node types as JavaScript for
+# operators, control flow, and assignments, so we reuse JS modifiers directly.
+MODIFIERS_PHP = MODIFIERS_JAVASCRIPT

--- a/swesmith/bug_gen/procedural/php/__init__.py
+++ b/swesmith/bug_gen/procedural/php/__init__.py
@@ -1,12 +1,49 @@
 """
 PHP procedural modifiers for bug generation.
 
-PHP shares most tree-sitter node types with JavaScript (binary_expression,
-if_statement, for_statement, etc.), so we reuse the JavaScript modifiers.
+Uses PHP-specific tree-sitter grammar for accurate AST parsing of PHP syntax
+(e.g., ->, ::, foreach, typed catches, string concatenation with .).
 """
 
-from swesmith.bug_gen.procedural.javascript import MODIFIERS_JAVASCRIPT
+from swesmith.bug_gen.procedural.base import ProceduralModifier
 
-# PHP uses the same tree-sitter AST node types as JavaScript for
-# operators, control flow, and assignments, so we reuse JS modifiers directly.
-MODIFIERS_PHP = MODIFIERS_JAVASCRIPT
+from swesmith.bug_gen.procedural.php.operations import (
+    OperationChangeModifier,
+    OperationFlipOperatorModifier,
+    OperationSwapOperandsModifier,
+    OperationChangeConstantsModifier,
+    OperationBreakChainsModifier,
+    AugmentedAssignmentSwapModifier,
+    TernaryOperatorSwapModifier,
+    FunctionArgumentSwapModifier,
+)
+from swesmith.bug_gen.procedural.php.control_flow import (
+    ControlIfElseInvertModifier,
+    ControlShuffleLinesModifier,
+)
+from swesmith.bug_gen.procedural.php.remove import (
+    RemoveLoopModifier,
+    RemoveConditionalModifier,
+    RemoveAssignmentModifier,
+    RemoveTernaryModifier,
+)
+
+MODIFIERS_PHP: list[ProceduralModifier] = [
+    # Operation modifiers (8)
+    OperationChangeModifier(likelihood=0.5),
+    OperationFlipOperatorModifier(likelihood=0.5),
+    OperationSwapOperandsModifier(likelihood=0.5),
+    OperationChangeConstantsModifier(likelihood=0.5),
+    OperationBreakChainsModifier(likelihood=0.5),
+    AugmentedAssignmentSwapModifier(likelihood=0.5),
+    TernaryOperatorSwapModifier(likelihood=0.5),
+    FunctionArgumentSwapModifier(likelihood=0.5),
+    # Control flow modifiers (2)
+    ControlIfElseInvertModifier(likelihood=0.5),
+    ControlShuffleLinesModifier(likelihood=0.5),
+    # Remove modifiers (4)
+    RemoveLoopModifier(likelihood=0.5),
+    RemoveConditionalModifier(likelihood=0.5),
+    RemoveAssignmentModifier(likelihood=0.5),
+    RemoveTernaryModifier(likelihood=0.5),
+]

--- a/swesmith/bug_gen/procedural/php/base.py
+++ b/swesmith/bug_gen/procedural/php/base.py
@@ -9,28 +9,17 @@ from tree_sitter import Language, Parser
 
 from swesmith.bug_gen.procedural.base import ProceduralModifier
 
-PHP_LANGUAGE = Language(tsphp.language_php())
-
-# PHP's tree-sitter parser requires the <?php tag to parse PHP code.
-# Entity src_code doesn't include it, so we prepend it before parsing
-# and strip it from the result after modification.
-PHP_TAG = "<?php\n"
+PHP_LANGUAGE = Language(tsphp.language_php_only())
 
 
 def php_parse(src_code: str):
-    """Parse PHP source code, prepending <?php tag if needed.
+    """Parse PHP source code using the php_only grammar.
 
-    Returns (tree, offset) where offset is the number of bytes added.
+    Returns (tree, offset) where offset is always 0.
     """
     parser = Parser(PHP_LANGUAGE)
-    if not src_code.lstrip().startswith("<?"):
-        wrapped = PHP_TAG + src_code
-        offset = len(PHP_TAG.encode("utf-8"))
-    else:
-        wrapped = src_code
-        offset = 0
-    tree = parser.parse(bytes(wrapped, "utf8"))
-    return tree, offset
+    tree = parser.parse(bytes(src_code, "utf8"))
+    return tree, 0
 
 
 class PhpProceduralModifier(ProceduralModifier, ABC):

--- a/swesmith/bug_gen/procedural/php/base.py
+++ b/swesmith/bug_gen/procedural/php/base.py
@@ -1,0 +1,39 @@
+"""
+Base class for PHP procedural modifications.
+"""
+
+from abc import ABC
+
+import tree_sitter_php as tsphp
+from tree_sitter import Language, Parser
+
+from swesmith.bug_gen.procedural.base import ProceduralModifier
+
+PHP_LANGUAGE = Language(tsphp.language_php())
+
+# PHP's tree-sitter parser requires the <?php tag to parse PHP code.
+# Entity src_code doesn't include it, so we prepend it before parsing
+# and strip it from the result after modification.
+PHP_TAG = "<?php\n"
+
+
+def php_parse(src_code: str):
+    """Parse PHP source code, prepending <?php tag if needed.
+
+    Returns (tree, offset) where offset is the number of bytes added.
+    """
+    parser = Parser(PHP_LANGUAGE)
+    if not src_code.lstrip().startswith("<?"):
+        wrapped = PHP_TAG + src_code
+        offset = len(PHP_TAG.encode("utf-8"))
+    else:
+        wrapped = src_code
+        offset = 0
+    tree = parser.parse(bytes(wrapped, "utf8"))
+    return tree, offset
+
+
+class PhpProceduralModifier(ProceduralModifier, ABC):
+    """Base class for PHP-specific procedural modifications using tree-sitter AST."""
+
+    pass

--- a/swesmith/bug_gen/procedural/php/control_flow.py
+++ b/swesmith/bug_gen/procedural/php/control_flow.py
@@ -62,16 +62,18 @@ class ControlIfElseInvertModifier(PhpProceduralModifier):
                         break
 
                 if condition and consequence and alternative and self.flip():
-                    modifications.append({
-                        "node_start": n.start_byte - offset,
-                        "node_end": n.end_byte - offset,
-                        "cond_start": condition.start_byte - offset,
-                        "cond_end": condition.end_byte - offset,
-                        "cons_start": consequence.start_byte - offset,
-                        "cons_end": consequence.end_byte - offset,
-                        "alt_start": alternative.start_byte - offset,
-                        "alt_end": alternative.end_byte - offset,
-                    })
+                    modifications.append(
+                        {
+                            "node_start": n.start_byte - offset,
+                            "node_end": n.end_byte - offset,
+                            "cond_start": condition.start_byte - offset,
+                            "cond_end": condition.end_byte - offset,
+                            "cons_start": consequence.start_byte - offset,
+                            "cons_end": consequence.end_byte - offset,
+                            "alt_start": alternative.start_byte - offset,
+                            "alt_end": alternative.end_byte - offset,
+                        }
+                    )
 
             for child in n.children:
                 collect_if_statements(child)
@@ -83,9 +85,15 @@ class ControlIfElseInvertModifier(PhpProceduralModifier):
 
         modified_source = source_bytes
         for mod in reversed(modifications):
-            condition_text = source_bytes[mod["cond_start"] : mod["cond_end"]].decode("utf-8")
-            consequence_text = source_bytes[mod["cons_start"] : mod["cons_end"]].decode("utf-8")
-            alternative_text = source_bytes[mod["alt_start"] : mod["alt_end"]].decode("utf-8")
+            condition_text = source_bytes[mod["cond_start"] : mod["cond_end"]].decode(
+                "utf-8"
+            )
+            consequence_text = source_bytes[mod["cons_start"] : mod["cons_end"]].decode(
+                "utf-8"
+            )
+            alternative_text = source_bytes[mod["alt_start"] : mod["alt_end"]].decode(
+                "utf-8"
+            )
 
             inverted = f"if {condition_text} {alternative_text} else {consequence_text}"
 
@@ -109,7 +117,9 @@ class ControlShuffleLinesModifier(PhpProceduralModifier):
     def modify(self, code_entity: CodeEntity) -> BugRewrite:
         tree, offset = php_parse(code_entity.src_code)
 
-        modified_code = self._shuffle_statements(code_entity.src_code, tree.root_node, offset)
+        modified_code = self._shuffle_statements(
+            code_entity.src_code, tree.root_node, offset
+        )
 
         if modified_code == code_entity.src_code:
             return None
@@ -140,11 +150,16 @@ class ControlShuffleLinesModifier(PhpProceduralModifier):
                         ]
 
                         if len(statements) >= 2 and self.flip():
-                            shuffles.append({
-                                "block_start": child.start_byte - offset,
-                                "block_end": child.end_byte - offset,
-                                "statements": [(s.start_byte - offset, s.end_byte - offset) for s in statements],
-                            })
+                            shuffles.append(
+                                {
+                                    "block_start": child.start_byte - offset,
+                                    "block_end": child.end_byte - offset,
+                                    "statements": [
+                                        (s.start_byte - offset, s.end_byte - offset)
+                                        for s in statements
+                                    ],
+                                }
+                            )
                         return
 
             for child in n.children:

--- a/swesmith/bug_gen/procedural/php/control_flow.py
+++ b/swesmith/bug_gen/procedural/php/control_flow.py
@@ -65,7 +65,13 @@ class ControlIfElseInvertModifier(PhpProceduralModifier):
                         break
 
                 # Skip if/elseif/else chains to avoid dropping elseif branches
-                if condition and consequence and alternative and not has_elseif and self.flip():
+                if (
+                    condition
+                    and consequence
+                    and alternative
+                    and not has_elseif
+                    and self.flip()
+                ):
                     modifications.append(
                         {
                             "node_start": n.start_byte - offset,

--- a/swesmith/bug_gen/procedural/php/control_flow.py
+++ b/swesmith/bug_gen/procedural/php/control_flow.py
@@ -46,6 +46,7 @@ class ControlIfElseInvertModifier(PhpProceduralModifier):
                 condition = None
                 consequence = None
                 alternative = None
+                has_elseif = False
 
                 for child in n.children:
                     if child.type == "if":
@@ -54,6 +55,8 @@ class ControlIfElseInvertModifier(PhpProceduralModifier):
                         condition = child
                     elif child.type == "compound_statement" and consequence is None:
                         consequence = child
+                    elif child.type == "else_if_clause":
+                        has_elseif = True
                     elif child.type == "else_clause":
                         for else_child in child.children:
                             if else_child.type == "compound_statement":
@@ -61,7 +64,8 @@ class ControlIfElseInvertModifier(PhpProceduralModifier):
                                 break
                         break
 
-                if condition and consequence and alternative and self.flip():
+                # Skip if/elseif/else chains to avoid dropping elseif branches
+                if condition and consequence and alternative and not has_elseif and self.flip():
                     modifications.append(
                         {
                             "node_start": n.start_byte - offset,
@@ -138,7 +142,6 @@ class ControlShuffleLinesModifier(PhpProceduralModifier):
             if n.type in [
                 "function_definition",
                 "method_declaration",
-                "arrow_function",
             ]:
                 for child in n.children:
                     if child.type == "compound_statement":

--- a/swesmith/bug_gen/procedural/php/control_flow.py
+++ b/swesmith/bug_gen/procedural/php/control_flow.py
@@ -1,0 +1,186 @@
+"""
+PHP control flow modifiers for procedural bug generation using tree-sitter.
+"""
+
+from swesmith.bug_gen.procedural.base import CommonPMs
+from swesmith.bug_gen.procedural.php.base import PhpProceduralModifier, php_parse
+from swesmith.constants import BugRewrite, CodeEntity
+
+
+class ControlIfElseInvertModifier(PhpProceduralModifier):
+    """Invert if-else blocks by swapping their bodies"""
+
+    explanation: str = CommonPMs.CONTROL_IF_ELSE_INVERT.explanation
+    name: str = CommonPMs.CONTROL_IF_ELSE_INVERT.name
+    conditions: list = CommonPMs.CONTROL_IF_ELSE_INVERT.conditions
+    min_complexity: int = 5
+
+    def modify(self, code_entity: CodeEntity) -> BugRewrite:
+        tree, offset = php_parse(code_entity.src_code)
+
+        changed = False
+        for _ in range(self.max_attempts):
+            modified_code = self._invert_if_else_statements(
+                code_entity.src_code, tree.root_node, offset
+            )
+
+            if modified_code != code_entity.src_code:
+                changed = True
+                break
+
+        if not changed:
+            return None
+
+        return BugRewrite(
+            rewrite=modified_code,
+            explanation=self.explanation,
+            strategy=self.name,
+        )
+
+    def _invert_if_else_statements(self, source_code: str, node, offset: int) -> str:
+        modifications = []
+        source_bytes = source_code.encode("utf-8")
+
+        def collect_if_statements(n):
+            if n.type == "if_statement":
+                condition = None
+                consequence = None
+                alternative = None
+
+                for child in n.children:
+                    if child.type == "if":
+                        continue
+                    elif child.type == "parenthesized_expression":
+                        condition = child
+                    elif child.type == "compound_statement" and consequence is None:
+                        consequence = child
+                    elif child.type == "else_clause":
+                        for else_child in child.children:
+                            if else_child.type == "compound_statement":
+                                alternative = else_child
+                                break
+                        break
+
+                if condition and consequence and alternative and self.flip():
+                    modifications.append({
+                        "node_start": n.start_byte - offset,
+                        "node_end": n.end_byte - offset,
+                        "cond_start": condition.start_byte - offset,
+                        "cond_end": condition.end_byte - offset,
+                        "cons_start": consequence.start_byte - offset,
+                        "cons_end": consequence.end_byte - offset,
+                        "alt_start": alternative.start_byte - offset,
+                        "alt_end": alternative.end_byte - offset,
+                    })
+
+            for child in n.children:
+                collect_if_statements(child)
+
+        collect_if_statements(node)
+
+        if not modifications:
+            return source_code
+
+        modified_source = source_bytes
+        for mod in reversed(modifications):
+            condition_text = source_bytes[mod["cond_start"] : mod["cond_end"]].decode("utf-8")
+            consequence_text = source_bytes[mod["cons_start"] : mod["cons_end"]].decode("utf-8")
+            alternative_text = source_bytes[mod["alt_start"] : mod["alt_end"]].decode("utf-8")
+
+            inverted = f"if {condition_text} {alternative_text} else {consequence_text}"
+
+            modified_source = (
+                modified_source[: mod["node_start"]]
+                + inverted.encode("utf-8")
+                + modified_source[mod["node_end"] :]
+            )
+
+        return modified_source.decode("utf-8")
+
+
+class ControlShuffleLinesModifier(PhpProceduralModifier):
+    """Shuffle independent statements within a function body"""
+
+    explanation: str = CommonPMs.CONTROL_SHUFFLE_LINES.explanation
+    name: str = CommonPMs.CONTROL_SHUFFLE_LINES.name
+    conditions: list = CommonPMs.CONTROL_SHUFFLE_LINES.conditions
+    max_complexity: int = 10
+
+    def modify(self, code_entity: CodeEntity) -> BugRewrite:
+        tree, offset = php_parse(code_entity.src_code)
+
+        modified_code = self._shuffle_statements(code_entity.src_code, tree.root_node, offset)
+
+        if modified_code == code_entity.src_code:
+            return None
+
+        return BugRewrite(
+            rewrite=modified_code,
+            explanation=self.explanation,
+            strategy=self.name,
+        )
+
+    def _shuffle_statements(self, source_code: str, node, offset: int) -> str:
+        shuffles = []
+        source_bytes = source_code.encode("utf-8")
+
+        def collect_function_bodies(n):
+            if n.type in [
+                "function_definition",
+                "method_declaration",
+                "arrow_function",
+            ]:
+                for child in n.children:
+                    if child.type == "compound_statement":
+                        statements = [
+                            c
+                            for c in child.children
+                            if c.type not in ["{", "}", "\n"]
+                            and c.type.endswith("statement")
+                        ]
+
+                        if len(statements) >= 2 and self.flip():
+                            shuffles.append({
+                                "block_start": child.start_byte - offset,
+                                "block_end": child.end_byte - offset,
+                                "statements": [(s.start_byte - offset, s.end_byte - offset) for s in statements],
+                            })
+                        return
+
+            for child in n.children:
+                collect_function_bodies(child)
+
+        collect_function_bodies(node)
+
+        if not shuffles:
+            return source_code
+
+        modified_source = source_bytes
+        for shuffle_info in reversed(shuffles):
+            stmts = shuffle_info["statements"]
+
+            stmt_texts = [source_bytes[s:e].decode("utf-8") for s, e in stmts]
+            self.rand.shuffle(stmt_texts)
+
+            block_start = shuffle_info["block_start"]
+            block_end = shuffle_info["block_end"]
+
+            first_stmt_start = stmts[0][0]
+            indent_start = first_stmt_start
+            while indent_start > block_start and source_bytes[indent_start - 1] in [
+                ord(" "),
+                ord("\t"),
+            ]:
+                indent_start -= 1
+
+            indent = source_bytes[indent_start:first_stmt_start].decode("utf-8")
+
+            new_block = "{\n" + indent + f"\n{indent}".join(stmt_texts) + "\n}"
+
+            modified_source = (
+                modified_source[:block_start]
+                + new_block.encode("utf-8")
+                + modified_source[block_end:]
+            )
+
+        return modified_source.decode("utf-8")

--- a/swesmith/bug_gen/procedural/php/operations.py
+++ b/swesmith/bug_gen/procedural/php/operations.py
@@ -1,0 +1,615 @@
+"""
+PHP operation modifiers for procedural bug generation using tree-sitter.
+"""
+
+import sys
+from swesmith.bug_gen.procedural.php.base import PhpProceduralModifier, php_parse
+from swesmith.bug_gen.procedural.base import CommonPMs
+from swesmith.constants import CodeProperty, BugRewrite, CodeEntity
+
+
+def _safe_decode(bytes_obj, fallback=""):
+    """Safely decode bytes to UTF-8, handling potential encoding errors."""
+    try:
+        return bytes_obj.decode("utf-8")
+    except UnicodeDecodeError as e:
+        print(f"WARNING: UTF-8 decode error: {e}", file=sys.stderr)
+        return fallback
+
+
+class OperationChangeModifier(PhpProceduralModifier):
+    """Change operators within similar groups (e.g., +/-, *//%, etc.)"""
+
+    explanation: str = CommonPMs.OPERATION_CHANGE.explanation
+    name: str = CommonPMs.OPERATION_CHANGE.name
+    conditions: list = CommonPMs.OPERATION_CHANGE.conditions
+
+    def modify(self, code_entity: CodeEntity) -> BugRewrite:
+        tree, offset = php_parse(code_entity.src_code)
+
+        modified_code = self._change_operators(code_entity.src_code, tree.root_node, offset)
+
+        if modified_code == code_entity.src_code:
+            return None
+
+        return BugRewrite(
+            rewrite=modified_code,
+            explanation=self.explanation,
+            strategy=self.name,
+        )
+
+    def _change_operators(self, source_code: str, node, offset: int) -> str:
+        changes = []
+
+        operator_groups = {
+            "+": ["+", "-"],
+            "-": ["+", "-"],
+            "*": ["*", "/", "%"],
+            "/": ["*", "/", "%"],
+            "%": ["*", "/", "%"],
+            "&": ["&", "|", "^"],
+            "|": ["&", "|", "^"],
+            "^": ["&", "|", "^"],
+            "<<": ["<<", ">>"],
+            ">>": ["<<", ">>"],
+            ".": [".", "+"],  # PHP string concatenation
+        }
+
+        def collect_binary_ops(n):
+            if n.type == "binary_expression":
+                for child in n.children:
+                    if child.type in operator_groups:
+                        operator = child.type
+                        group = operator_groups[operator]
+                        other_ops = [op for op in group if op != operator]
+                        if other_ops and self.flip():
+                            new_op = self.rand.choice(other_ops)
+                            changes.append({
+                                "start": child.start_byte - offset,
+                                "end": child.end_byte - offset,
+                                "new_op": new_op,
+                            })
+                        break
+
+            for child in n.children:
+                collect_binary_ops(child)
+
+        collect_binary_ops(node)
+
+        if not changes:
+            return source_code
+
+        modified_source = source_code.encode("utf-8")
+        for change in reversed(changes):
+            modified_source = (
+                modified_source[: change["start"]]
+                + change["new_op"].encode("utf-8")
+                + modified_source[change["end"] :]
+            )
+
+        return _safe_decode(modified_source, source_code)
+
+
+class OperationFlipOperatorModifier(PhpProceduralModifier):
+    """Flip operators to their opposites (e.g., == to !=, < to >, etc.)"""
+
+    explanation: str = "The operators in an expression are likely incorrect."
+    name: str = "func_pm_op_flip"
+    conditions: list = [CodeProperty.IS_FUNCTION, CodeProperty.HAS_BINARY_OP]
+
+    def modify(self, code_entity: CodeEntity) -> BugRewrite:
+        tree, offset = php_parse(code_entity.src_code)
+
+        modified_code = self._flip_operators(code_entity.src_code, tree.root_node, offset)
+
+        if modified_code == code_entity.src_code:
+            return None
+
+        return BugRewrite(
+            rewrite=modified_code,
+            explanation=self.explanation,
+            strategy=self.name,
+        )
+
+    def _flip_operators(self, source_code: str, node, offset: int) -> str:
+        changes = []
+
+        operator_flips = {
+            "===": "!==",
+            "!==": "===",
+            "==": "!=",
+            "!=": "==",
+            "<=": ">",
+            ">=": "<",
+            "<": ">=",
+            ">": "<=",
+            "&&": "||",
+            "||": "&&",
+            "and": "or",
+            "or": "and",
+            "+": "-",
+            "-": "+",
+            "*": "/",
+            "/": "*",
+            ".": "+",  # PHP concat to addition
+        }
+
+        def collect_binary_ops(n):
+            if n.type == "binary_expression":
+                for child in n.children:
+                    if child.type in operator_flips:
+                        if self.flip():
+                            changes.append({
+                                "start": child.start_byte - offset,
+                                "end": child.end_byte - offset,
+                                "new_op": operator_flips[child.type],
+                            })
+                        break
+
+            for child in n.children:
+                collect_binary_ops(child)
+
+        collect_binary_ops(node)
+
+        if not changes:
+            return source_code
+
+        modified_source = source_code.encode("utf-8")
+        for change in reversed(changes):
+            modified_source = (
+                modified_source[: change["start"]]
+                + change["new_op"].encode("utf-8")
+                + modified_source[change["end"] :]
+            )
+
+        return _safe_decode(modified_source, source_code)
+
+
+class OperationSwapOperandsModifier(PhpProceduralModifier):
+    """Swap operands in binary operations (e.g., a + b becomes b + a)"""
+
+    explanation: str = CommonPMs.OPERATION_SWAP_OPERANDS.explanation
+    name: str = CommonPMs.OPERATION_SWAP_OPERANDS.name
+    conditions: list = CommonPMs.OPERATION_SWAP_OPERANDS.conditions
+
+    def modify(self, code_entity: CodeEntity) -> BugRewrite:
+        tree, offset = php_parse(code_entity.src_code)
+
+        modified_code = self._swap_operands(code_entity.src_code, tree.root_node, offset)
+
+        if modified_code == code_entity.src_code:
+            return None
+
+        return BugRewrite(
+            rewrite=modified_code,
+            explanation=self.explanation,
+            strategy=self.name,
+        )
+
+    def _swap_operands(self, source_code: str, node, offset: int) -> str:
+        changes = []
+        source_bytes = source_code.encode("utf-8")
+
+        def collect_binary_ops(n):
+            if n.type == "binary_expression" and len(n.children) >= 3:
+                left = n.children[0]
+                operator_node = n.children[1]
+                right = n.children[2]
+
+                if self.flip():
+                    operator = operator_node.type
+                    if operator in ["<", ">", "<=", ">="]:
+                        op_flip = {"<": ">", ">": "<", "<=": ">=", ">=": "<="}
+                        operator = op_flip.get(operator, operator)
+
+                    changes.append({
+                        "node_start": n.start_byte - offset,
+                        "node_end": n.end_byte - offset,
+                        "left_start": left.start_byte - offset,
+                        "left_end": left.end_byte - offset,
+                        "right_start": right.start_byte - offset,
+                        "right_end": right.end_byte - offset,
+                        "operator": operator,
+                    })
+
+            for child in n.children:
+                collect_binary_ops(child)
+
+        collect_binary_ops(node)
+
+        if not changes:
+            return source_code
+
+        modified_source = source_bytes
+        for change in reversed(changes):
+            left_text = _safe_decode(source_bytes[change["left_start"] : change["left_end"]])
+            right_text = _safe_decode(source_bytes[change["right_start"] : change["right_end"]])
+
+            swapped = f"{right_text} {change['operator']} {left_text}"
+
+            modified_source = (
+                modified_source[: change["node_start"]]
+                + swapped.encode("utf-8")
+                + modified_source[change["node_end"] :]
+            )
+
+        return _safe_decode(modified_source, source_code)
+
+
+class OperationChangeConstantsModifier(PhpProceduralModifier):
+    """Change numeric constants to introduce off-by-one errors"""
+
+    explanation: str = CommonPMs.OPERATION_CHANGE_CONSTANTS.explanation
+    name: str = CommonPMs.OPERATION_CHANGE_CONSTANTS.name
+    conditions: list = CommonPMs.OPERATION_CHANGE_CONSTANTS.conditions
+
+    def modify(self, code_entity: CodeEntity) -> BugRewrite:
+        tree, offset = php_parse(code_entity.src_code)
+
+        modified_code = self._change_constants(code_entity.src_code, tree.root_node, offset)
+
+        if modified_code == code_entity.src_code:
+            return None
+
+        return BugRewrite(
+            rewrite=modified_code,
+            explanation=self.explanation,
+            strategy=self.name,
+        )
+
+    def _change_constants(self, source_code: str, node, offset: int) -> str:
+        changes = []
+        source_bytes = source_code.encode("utf-8")
+
+        def collect_numbers(n):
+            # PHP uses "integer" instead of "number"
+            if n.type == "integer" and self.flip():
+                try:
+                    start = n.start_byte - offset
+                    end = n.end_byte - offset
+                    value_text = _safe_decode(source_bytes[start:end])
+                    value = int(value_text)
+                    new_value = value + self.rand.choice([-1, 1, -2, 2])
+                    changes.append({"start": start, "end": end, "new_value": str(new_value)})
+                except ValueError:
+                    pass
+
+            for child in n.children:
+                collect_numbers(child)
+
+        collect_numbers(node)
+
+        if not changes:
+            return source_code
+
+        modified_source = source_bytes
+        for change in reversed(changes):
+            modified_source = (
+                modified_source[: change["start"]]
+                + change["new_value"].encode("utf-8")
+                + modified_source[change["end"] :]
+            )
+
+        return _safe_decode(modified_source, source_code)
+
+
+class OperationBreakChainsModifier(PhpProceduralModifier):
+    """Break chained operations by removing parts of the chain"""
+
+    explanation: str = CommonPMs.OPERATION_BREAK_CHAINS.explanation
+    name: str = CommonPMs.OPERATION_BREAK_CHAINS.name
+    conditions: list = CommonPMs.OPERATION_BREAK_CHAINS.conditions
+
+    def modify(self, code_entity: CodeEntity) -> BugRewrite:
+        tree, offset = php_parse(code_entity.src_code)
+
+        modified_code = self._break_chains(code_entity.src_code, tree.root_node, offset)
+
+        if modified_code == code_entity.src_code:
+            return None
+
+        return BugRewrite(
+            rewrite=modified_code,
+            explanation=self.explanation,
+            strategy=self.name,
+        )
+
+    def _break_chains(self, source_code: str, node, offset: int) -> str:
+        changes = []
+        source_bytes = source_code.encode("utf-8")
+
+        def collect_chains(n):
+            if n.type == "binary_expression" and len(n.children) >= 3:
+                left = n.children[0]
+                operator = n.children[1]
+                right = n.children[2]
+
+                if left.type == "binary_expression" and self.flip():
+                    if len(left.children) >= 3:
+                        left_right = left.children[2]
+                        lr_text = _safe_decode(source_bytes[left_right.start_byte - offset : left_right.end_byte - offset])
+                        op_text = _safe_decode(source_bytes[operator.start_byte - offset : operator.end_byte - offset])
+                        r_text = _safe_decode(source_bytes[right.start_byte - offset : right.end_byte - offset])
+                        changes.append({
+                            "start": n.start_byte - offset,
+                            "end": n.end_byte - offset,
+                            "replacement": f"{lr_text} {op_text} {r_text}",
+                        })
+
+                elif right.type == "binary_expression" and self.flip():
+                    if len(right.children) >= 3:
+                        right_left = right.children[0]
+                        l_text = _safe_decode(source_bytes[left.start_byte - offset : left.end_byte - offset])
+                        op_text = _safe_decode(source_bytes[operator.start_byte - offset : operator.end_byte - offset])
+                        rl_text = _safe_decode(source_bytes[right_left.start_byte - offset : right_left.end_byte - offset])
+                        changes.append({
+                            "start": n.start_byte - offset,
+                            "end": n.end_byte - offset,
+                            "replacement": f"{l_text} {op_text} {rl_text}",
+                        })
+
+            for child in n.children:
+                collect_chains(child)
+
+        collect_chains(node)
+
+        if not changes:
+            return source_code
+
+        modified_source = source_bytes
+        for change in reversed(changes):
+            modified_source = (
+                modified_source[: change["start"]]
+                + change["replacement"].encode("utf-8")
+                + modified_source[change["end"] :]
+            )
+
+        return _safe_decode(modified_source, source_code)
+
+
+class AugmentedAssignmentSwapModifier(PhpProceduralModifier):
+    """Swap augmented assignment operators (+=, -=, *=, /=, etc.) and update expressions (++, --)"""
+
+    explanation: str = (
+        "The augmented assignment or update operator is likely incorrect."
+    )
+    name: str = "func_pm_aug_assign_swap"
+    conditions: list = [CodeProperty.IS_FUNCTION, CodeProperty.HAS_ASSIGNMENT]
+
+    def modify(self, code_entity: CodeEntity) -> BugRewrite:
+        tree, offset = php_parse(code_entity.src_code)
+
+        modified_code = self._swap_augmented_assignments(
+            code_entity.src_code, tree.root_node, offset
+        )
+
+        if modified_code == code_entity.src_code:
+            return None
+
+        return BugRewrite(
+            rewrite=modified_code,
+            explanation=self.explanation,
+            strategy=self.name,
+        )
+
+    def _swap_augmented_assignments(self, source_code: str, node, offset: int) -> str:
+        changes = []
+        source_bytes = source_code.encode("utf-8")
+
+        aug_assign_swaps = {
+            "+=": "-=",
+            "-=": "+=",
+            "*=": "/=",
+            "/=": "*=",
+            "%=": "/=",
+            "&=": "|=",
+            "|=": "&=",
+            "^=": "&=",
+            "<<=": ">>=",
+            ">>=": "<<=",
+            ".=": "+=",  # PHP string concat assignment
+            "**=": "*=",
+            "??=": "||=",
+        }
+
+        update_swaps = {
+            "++": "--",
+            "--": "++",
+        }
+
+        def collect_augmented_assignments(n):
+            if n.type == "augmented_assignment_expression":
+                for child in n.children:
+                    op_text = source_bytes[child.start_byte - offset : child.end_byte - offset].decode("utf-8")
+                    if op_text in aug_assign_swaps and self.flip():
+                        changes.append({
+                            "start": child.start_byte - offset,
+                            "end": child.end_byte - offset,
+                            "new_op": aug_assign_swaps[op_text],
+                        })
+                        break
+
+            elif n.type == "update_expression":
+                for child in n.children:
+                    op_text = source_bytes[child.start_byte - offset : child.end_byte - offset].decode("utf-8")
+                    if op_text in update_swaps and self.flip():
+                        changes.append({
+                            "start": child.start_byte - offset,
+                            "end": child.end_byte - offset,
+                            "new_op": update_swaps[op_text],
+                        })
+                        break
+
+            for child in n.children:
+                collect_augmented_assignments(child)
+
+        collect_augmented_assignments(node)
+
+        if not changes:
+            return source_code
+
+        modified_source = source_bytes
+        for change in reversed(changes):
+            modified_source = (
+                modified_source[: change["start"]]
+                + change["new_op"].encode("utf-8")
+                + modified_source[change["end"] :]
+            )
+
+        return _safe_decode(modified_source, source_code)
+
+
+class TernaryOperatorSwapModifier(PhpProceduralModifier):
+    """Modify ternary operators (condition ? consequent : alternative)"""
+
+    explanation: str = "The ternary operator branches may be swapped or the condition may be incorrect."
+    name: str = "func_pm_ternary_swap"
+    conditions: list = [CodeProperty.IS_FUNCTION, CodeProperty.HAS_TERNARY]
+
+    def modify(self, code_entity: CodeEntity) -> BugRewrite:
+        tree, offset = php_parse(code_entity.src_code)
+
+        modified_code = self._modify_ternary(code_entity.src_code, tree.root_node, offset)
+
+        if modified_code == code_entity.src_code:
+            return None
+
+        return BugRewrite(
+            rewrite=modified_code,
+            explanation=self.explanation,
+            strategy=self.name,
+        )
+
+    def _modify_ternary(self, source_code: str, node, offset: int) -> str:
+        changes = []
+        source_bytes = source_code.encode("utf-8")
+
+        def collect_ternary_ops(n):
+            # PHP uses "conditional_expression" instead of "ternary_expression"
+            if n.type == "conditional_expression" and len(n.children) >= 5:
+                content_children = [c for c in n.children if c.type not in ["?", ":"]]
+                if len(content_children) >= 3:
+                    condition = content_children[0]
+                    consequent = content_children[1]
+                    alternative = content_children[2]
+
+                    if self.flip():
+                        mod_type = self.rand.choice(["swap_branches", "negate_condition"])
+                        changes.append({
+                            "start": n.start_byte - offset,
+                            "end": n.end_byte - offset,
+                            "cond_start": condition.start_byte - offset,
+                            "cond_end": condition.end_byte - offset,
+                            "cons_start": consequent.start_byte - offset,
+                            "cons_end": consequent.end_byte - offset,
+                            "alt_start": alternative.start_byte - offset,
+                            "alt_end": alternative.end_byte - offset,
+                            "mod_type": mod_type,
+                        })
+
+            for child in n.children:
+                collect_ternary_ops(child)
+
+        collect_ternary_ops(node)
+
+        if not changes:
+            return source_code
+
+        modified_source = source_bytes
+        for change in reversed(changes):
+            cond_text = _safe_decode(source_bytes[change["cond_start"] : change["cond_end"]])
+            cons_text = _safe_decode(source_bytes[change["cons_start"] : change["cons_end"]])
+            alt_text = _safe_decode(source_bytes[change["alt_start"] : change["alt_end"]])
+
+            if change["mod_type"] == "swap_branches":
+                new_ternary = f"{cond_text} ? {alt_text} : {cons_text}"
+            else:
+                new_ternary = f"!({cond_text}) ? {cons_text} : {alt_text}"
+
+            modified_source = (
+                modified_source[: change["start"]]
+                + new_ternary.encode("utf-8")
+                + modified_source[change["end"] :]
+            )
+
+        return _safe_decode(modified_source, source_code)
+
+
+class FunctionArgumentSwapModifier(PhpProceduralModifier):
+    """Swap adjacent arguments in function calls."""
+
+    explanation: str = "The function arguments may be in the wrong order."
+    name: str = "func_pm_arg_swap"
+    conditions: list = [CodeProperty.IS_FUNCTION, CodeProperty.HAS_FUNCTION_CALL]
+
+    def modify(self, code_entity: CodeEntity) -> BugRewrite:
+        tree, offset = php_parse(code_entity.src_code)
+
+        modified_code = self._swap_arguments(code_entity.src_code, tree.root_node, offset)
+
+        if modified_code == code_entity.src_code:
+            return None
+
+        return BugRewrite(
+            rewrite=modified_code,
+            explanation=self.explanation,
+            strategy=self.name,
+        )
+
+    def _swap_arguments(self, source_code: str, node, offset: int) -> str:
+        changes = []
+        source_bytes = source_code.encode("utf-8")
+
+        def collect_function_calls(n):
+            if n.type in ["function_call_expression", "member_call_expression", "scoped_call_expression"]:
+                args_node = None
+                for child in n.children:
+                    if child.type == "arguments":
+                        args_node = child
+                        break
+
+                if args_node:
+                    args = [c for c in args_node.children if c.type not in ["(", ")", ","]]
+
+                    if len(args) >= 2 and self.flip():
+                        swap_idx = self.rand.randint(0, len(args) - 2)
+                        changes.append({
+                            "args_start": args_node.start_byte - offset,
+                            "args_end": args_node.end_byte - offset,
+                            "args": [(a.start_byte - offset, a.end_byte - offset) for a in args],
+                            "swap_idx": swap_idx,
+                        })
+
+            for child in n.children:
+                collect_function_calls(child)
+
+        collect_function_calls(node)
+
+        if not changes:
+            return source_code
+
+        modified_source = source_bytes
+        for change in reversed(changes):
+            args = change["args"]
+            swap_idx = change["swap_idx"]
+
+            new_args_parts = []
+            for i, (start, end) in enumerate(args):
+                if i == swap_idx:
+                    s2, e2 = args[swap_idx + 1]
+                    new_args_parts.append(_safe_decode(source_bytes[s2:e2]))
+                elif i == swap_idx + 1:
+                    s1, e1 = args[swap_idx]
+                    new_args_parts.append(_safe_decode(source_bytes[s1:e1]))
+                else:
+                    new_args_parts.append(_safe_decode(source_bytes[start:end]))
+
+            new_args = "(" + ", ".join(new_args_parts) + ")"
+
+            modified_source = (
+                modified_source[: change["args_start"]]
+                + new_args.encode("utf-8")
+                + modified_source[change["args_end"] :]
+            )
+
+        return _safe_decode(modified_source, source_code)

--- a/swesmith/bug_gen/procedural/php/operations.py
+++ b/swesmith/bug_gen/procedural/php/operations.py
@@ -43,29 +43,29 @@ class OperationChangeModifier(PhpProceduralModifier):
     def _change_operators(self, source_code: str, node, offset: int) -> str:
         changes = []
 
-        operator_groups = {
-            "+": ["+", "-"],
-            "-": ["+", "-"],
-            "*": ["*", "/", "%"],
-            "/": ["*", "/", "%"],
-            "%": ["*", "/", "%"],
-            "&": ["&", "|", "^"],
-            "|": ["&", "|", "^"],
-            "^": ["&", "|", "^"],
-            "<<": ["<<", ">>"],
-            ">>": ["<<", ">>"],
-            ".": [".", "+"],  # PHP string concatenation
+        operator_swaps = {
+            "+": ["-"],
+            "-": ["+"],
+            "*": ["/", "%", "**"],
+            "/": ["*", "%", "**"],
+            "%": ["*", "/", "**"],
+            "**": ["*", "/", "%"],
+            "&": ["|", "^"],
+            "|": ["&", "^"],
+            "^": ["&", "|"],
+            "<<": [">>"],
+            ">>": ["<<"],
+            ".": ["+"],  # PHP string concatenation
         }
 
         def collect_binary_ops(n):
             if n.type == "binary_expression":
                 for child in n.children:
-                    if child.type in operator_groups:
+                    if child.type in operator_swaps:
                         operator = child.type
-                        group = operator_groups[operator]
-                        other_ops = [op for op in group if op != operator]
-                        if other_ops and self.flip():
-                            new_op = self.rand.choice(other_ops)
+                        candidates = operator_swaps[operator]
+                        if self.flip():
+                            new_op = self.rand.choice(candidates)
                             changes.append(
                                 {
                                     "start": child.start_byte - offset,
@@ -133,11 +133,6 @@ class OperationFlipOperatorModifier(PhpProceduralModifier):
             "||": "&&",
             "and": "or",
             "or": "and",
-            "+": "-",
-            "-": "+",
-            "*": "/",
-            "/": "*",
-            ".": "+",  # PHP concat to addition
         }
 
         def collect_binary_ops(n):
@@ -207,11 +202,6 @@ class OperationSwapOperandsModifier(PhpProceduralModifier):
                 right = n.children[2]
 
                 if self.flip():
-                    operator = operator_node.type
-                    if operator in ["<", ">", "<=", ">="]:
-                        op_flip = {"<": ">", ">": "<", "<=": ">=", ">=": "<="}
-                        operator = op_flip.get(operator, operator)
-
                     changes.append(
                         {
                             "node_start": n.start_byte - offset,
@@ -220,7 +210,7 @@ class OperationSwapOperandsModifier(PhpProceduralModifier):
                             "left_end": left.end_byte - offset,
                             "right_start": right.start_byte - offset,
                             "right_end": right.end_byte - offset,
-                            "operator": operator,
+                            "operator": operator_node.type,
                         }
                     )
 
@@ -275,19 +265,47 @@ class OperationChangeConstantsModifier(PhpProceduralModifier):
             strategy=self.name,
         )
 
+    @staticmethod
+    def _parse_php_int(value_text: str):
+        """Parse a PHP integer literal, returning (value, formatter) or (None, None)."""
+        lower = value_text.lower()
+        if lower.startswith("0x"):
+            return int(value_text, 16), lambda v: f"0x{v:X}"
+        elif lower.startswith("0b"):
+            return int(value_text, 2), lambda v: f"0b{v:b}"
+        elif lower.startswith("0o"):
+            return int(value_text, 8), lambda v: f"0o{v:o}"
+        elif len(value_text) > 1 and value_text.startswith("0") and value_text.isdigit():
+            # Legacy octal (e.g., 077)
+            return int(value_text, 8), lambda v: f"0{v:o}"
+        else:
+            return int(value_text), str
+
     def _change_constants(self, source_code: str, node, offset: int) -> str:
         changes = []
         source_bytes = source_code.encode("utf-8")
 
         def collect_numbers(n):
-            # PHP uses "integer" instead of "number"
             if n.type == "integer" and self.flip():
                 try:
                     start = n.start_byte - offset
                     end = n.end_byte - offset
                     value_text = _safe_decode(source_bytes[start:end])
-                    value = int(value_text)
-                    new_value = value + self.rand.choice([-1, 1, -2, 2])
+                    value, fmt = self._parse_php_int(value_text)
+                    if value is not None:
+                        new_value = value + self.rand.choice([-1, 1, -2, 2])
+                        changes.append(
+                            {"start": start, "end": end, "new_value": fmt(new_value)}
+                        )
+                except ValueError:
+                    pass
+            elif n.type == "float" and self.flip():
+                try:
+                    start = n.start_byte - offset
+                    end = n.end_byte - offset
+                    value_text = _safe_decode(source_bytes[start:end])
+                    value = float(value_text)
+                    new_value = value + self.rand.choice([-1.0, 1.0, -0.5, 0.5])
                     changes.append(
                         {"start": start, "end": end, "new_value": str(new_value)}
                     )
@@ -339,6 +357,7 @@ class OperationBreakChainsModifier(PhpProceduralModifier):
         source_bytes = source_code.encode("utf-8")
 
         def collect_chains(n):
+            matched = False
             if n.type == "binary_expression" and len(n.children) >= 3:
                 left = n.children[0]
                 operator = n.children[1]
@@ -371,6 +390,7 @@ class OperationBreakChainsModifier(PhpProceduralModifier):
                                 "replacement": f"{lr_text} {op_text} {r_text}",
                             }
                         )
+                        matched = True
 
                 elif right.type == "binary_expression" and self.flip():
                     if len(right.children) >= 3:
@@ -399,9 +419,13 @@ class OperationBreakChainsModifier(PhpProceduralModifier):
                                 "replacement": f"{l_text} {op_text} {rl_text}",
                             }
                         )
+                        matched = True
 
-            for child in n.children:
-                collect_chains(child)
+            # Don't recurse into children of a matched node to avoid
+            # overlapping changes that would corrupt byte offsets
+            if not matched:
+                for child in n.children:
+                    collect_chains(child)
 
         collect_chains(node)
 

--- a/swesmith/bug_gen/procedural/php/operations.py
+++ b/swesmith/bug_gen/procedural/php/operations.py
@@ -461,7 +461,7 @@ class AugmentedAssignmentSwapModifier(PhpProceduralModifier):
             ">>=": "<<=",
             ".=": "+=",  # PHP string concat assignment
             "**=": "*=",
-            "??=": "||=",
+            "??=": ".=",
         }
 
         update_swaps = {
@@ -639,6 +639,7 @@ class FunctionArgumentSwapModifier(PhpProceduralModifier):
                 "function_call_expression",
                 "member_call_expression",
                 "scoped_call_expression",
+                "nullsafe_member_call_expression",
             ]:
                 args_node = None
                 for child in n.children:

--- a/swesmith/bug_gen/procedural/php/operations.py
+++ b/swesmith/bug_gen/procedural/php/operations.py
@@ -266,22 +266,15 @@ class OperationChangeConstantsModifier(PhpProceduralModifier):
         )
 
     @staticmethod
-    def _parse_php_int(value_text: str):
-        """Parse a PHP integer literal, returning (value, formatter) or (None, None)."""
+    def _parse_php_int(value_text: str) -> int:
+        """Parse a PHP integer literal, returning its integer value."""
         lower = value_text.lower()
-        if lower.startswith("0x"):
-            return int(value_text, 16), lambda v: f"0x{v:X}"
-        elif lower.startswith("0b"):
-            return int(value_text, 2), lambda v: f"0b{v:b}"
-        elif lower.startswith("0o"):
-            return int(value_text, 8), lambda v: f"0o{v:o}"
-        elif (
-            len(value_text) > 1 and value_text.startswith("0") and value_text.isdigit()
-        ):
-            # Legacy octal (e.g., 077)
-            return int(value_text, 8), lambda v: f"0{v:o}"
-        else:
-            return int(value_text), str
+        for prefix, base in [("0x", 16), ("0b", 2), ("0o", 8)]:
+            if lower.startswith(prefix):
+                return int(value_text, base)
+        if len(value_text) > 1 and value_text.startswith("0") and value_text.isdigit():
+            return int(value_text, 8)
+        return int(value_text)
 
     def _change_constants(self, source_code: str, node, offset: int) -> str:
         changes = []
@@ -293,12 +286,11 @@ class OperationChangeConstantsModifier(PhpProceduralModifier):
                     start = n.start_byte - offset
                     end = n.end_byte - offset
                     value_text = _safe_decode(source_bytes[start:end])
-                    value, fmt = self._parse_php_int(value_text)
-                    if value is not None:
-                        new_value = value + self.rand.choice([-1, 1, -2, 2])
-                        changes.append(
-                            {"start": start, "end": end, "new_value": fmt(new_value)}
-                        )
+                    value = self._parse_php_int(value_text)
+                    new_value = value + self.rand.choice([-1, 1, -2, 2])
+                    changes.append(
+                        {"start": start, "end": end, "new_value": str(new_value)}
+                    )
                 except ValueError:
                     pass
             elif n.type == "float" and self.flip():

--- a/swesmith/bug_gen/procedural/php/operations.py
+++ b/swesmith/bug_gen/procedural/php/operations.py
@@ -275,7 +275,9 @@ class OperationChangeConstantsModifier(PhpProceduralModifier):
             return int(value_text, 2), lambda v: f"0b{v:b}"
         elif lower.startswith("0o"):
             return int(value_text, 8), lambda v: f"0o{v:o}"
-        elif len(value_text) > 1 and value_text.startswith("0") and value_text.isdigit():
+        elif (
+            len(value_text) > 1 and value_text.startswith("0") and value_text.isdigit()
+        ):
             # Legacy octal (e.g., 077)
             return int(value_text, 8), lambda v: f"0{v:o}"
         else:

--- a/swesmith/bug_gen/procedural/php/operations.py
+++ b/swesmith/bug_gen/procedural/php/operations.py
@@ -27,7 +27,9 @@ class OperationChangeModifier(PhpProceduralModifier):
     def modify(self, code_entity: CodeEntity) -> BugRewrite:
         tree, offset = php_parse(code_entity.src_code)
 
-        modified_code = self._change_operators(code_entity.src_code, tree.root_node, offset)
+        modified_code = self._change_operators(
+            code_entity.src_code, tree.root_node, offset
+        )
 
         if modified_code == code_entity.src_code:
             return None
@@ -64,11 +66,13 @@ class OperationChangeModifier(PhpProceduralModifier):
                         other_ops = [op for op in group if op != operator]
                         if other_ops and self.flip():
                             new_op = self.rand.choice(other_ops)
-                            changes.append({
-                                "start": child.start_byte - offset,
-                                "end": child.end_byte - offset,
-                                "new_op": new_op,
-                            })
+                            changes.append(
+                                {
+                                    "start": child.start_byte - offset,
+                                    "end": child.end_byte - offset,
+                                    "new_op": new_op,
+                                }
+                            )
                         break
 
             for child in n.children:
@@ -100,7 +104,9 @@ class OperationFlipOperatorModifier(PhpProceduralModifier):
     def modify(self, code_entity: CodeEntity) -> BugRewrite:
         tree, offset = php_parse(code_entity.src_code)
 
-        modified_code = self._flip_operators(code_entity.src_code, tree.root_node, offset)
+        modified_code = self._flip_operators(
+            code_entity.src_code, tree.root_node, offset
+        )
 
         if modified_code == code_entity.src_code:
             return None
@@ -139,11 +145,13 @@ class OperationFlipOperatorModifier(PhpProceduralModifier):
                 for child in n.children:
                     if child.type in operator_flips:
                         if self.flip():
-                            changes.append({
-                                "start": child.start_byte - offset,
-                                "end": child.end_byte - offset,
-                                "new_op": operator_flips[child.type],
-                            })
+                            changes.append(
+                                {
+                                    "start": child.start_byte - offset,
+                                    "end": child.end_byte - offset,
+                                    "new_op": operator_flips[child.type],
+                                }
+                            )
                         break
 
             for child in n.children:
@@ -175,7 +183,9 @@ class OperationSwapOperandsModifier(PhpProceduralModifier):
     def modify(self, code_entity: CodeEntity) -> BugRewrite:
         tree, offset = php_parse(code_entity.src_code)
 
-        modified_code = self._swap_operands(code_entity.src_code, tree.root_node, offset)
+        modified_code = self._swap_operands(
+            code_entity.src_code, tree.root_node, offset
+        )
 
         if modified_code == code_entity.src_code:
             return None
@@ -202,15 +212,17 @@ class OperationSwapOperandsModifier(PhpProceduralModifier):
                         op_flip = {"<": ">", ">": "<", "<=": ">=", ">=": "<="}
                         operator = op_flip.get(operator, operator)
 
-                    changes.append({
-                        "node_start": n.start_byte - offset,
-                        "node_end": n.end_byte - offset,
-                        "left_start": left.start_byte - offset,
-                        "left_end": left.end_byte - offset,
-                        "right_start": right.start_byte - offset,
-                        "right_end": right.end_byte - offset,
-                        "operator": operator,
-                    })
+                    changes.append(
+                        {
+                            "node_start": n.start_byte - offset,
+                            "node_end": n.end_byte - offset,
+                            "left_start": left.start_byte - offset,
+                            "left_end": left.end_byte - offset,
+                            "right_start": right.start_byte - offset,
+                            "right_end": right.end_byte - offset,
+                            "operator": operator,
+                        }
+                    )
 
             for child in n.children:
                 collect_binary_ops(child)
@@ -222,8 +234,12 @@ class OperationSwapOperandsModifier(PhpProceduralModifier):
 
         modified_source = source_bytes
         for change in reversed(changes):
-            left_text = _safe_decode(source_bytes[change["left_start"] : change["left_end"]])
-            right_text = _safe_decode(source_bytes[change["right_start"] : change["right_end"]])
+            left_text = _safe_decode(
+                source_bytes[change["left_start"] : change["left_end"]]
+            )
+            right_text = _safe_decode(
+                source_bytes[change["right_start"] : change["right_end"]]
+            )
 
             swapped = f"{right_text} {change['operator']} {left_text}"
 
@@ -246,7 +262,9 @@ class OperationChangeConstantsModifier(PhpProceduralModifier):
     def modify(self, code_entity: CodeEntity) -> BugRewrite:
         tree, offset = php_parse(code_entity.src_code)
 
-        modified_code = self._change_constants(code_entity.src_code, tree.root_node, offset)
+        modified_code = self._change_constants(
+            code_entity.src_code, tree.root_node, offset
+        )
 
         if modified_code == code_entity.src_code:
             return None
@@ -270,7 +288,9 @@ class OperationChangeConstantsModifier(PhpProceduralModifier):
                     value_text = _safe_decode(source_bytes[start:end])
                     value = int(value_text)
                     new_value = value + self.rand.choice([-1, 1, -2, 2])
-                    changes.append({"start": start, "end": end, "new_value": str(new_value)})
+                    changes.append(
+                        {"start": start, "end": end, "new_value": str(new_value)}
+                    )
                 except ValueError:
                     pass
 
@@ -327,26 +347,58 @@ class OperationBreakChainsModifier(PhpProceduralModifier):
                 if left.type == "binary_expression" and self.flip():
                     if len(left.children) >= 3:
                         left_right = left.children[2]
-                        lr_text = _safe_decode(source_bytes[left_right.start_byte - offset : left_right.end_byte - offset])
-                        op_text = _safe_decode(source_bytes[operator.start_byte - offset : operator.end_byte - offset])
-                        r_text = _safe_decode(source_bytes[right.start_byte - offset : right.end_byte - offset])
-                        changes.append({
-                            "start": n.start_byte - offset,
-                            "end": n.end_byte - offset,
-                            "replacement": f"{lr_text} {op_text} {r_text}",
-                        })
+                        lr_text = _safe_decode(
+                            source_bytes[
+                                left_right.start_byte - offset : left_right.end_byte
+                                - offset
+                            ]
+                        )
+                        op_text = _safe_decode(
+                            source_bytes[
+                                operator.start_byte - offset : operator.end_byte
+                                - offset
+                            ]
+                        )
+                        r_text = _safe_decode(
+                            source_bytes[
+                                right.start_byte - offset : right.end_byte - offset
+                            ]
+                        )
+                        changes.append(
+                            {
+                                "start": n.start_byte - offset,
+                                "end": n.end_byte - offset,
+                                "replacement": f"{lr_text} {op_text} {r_text}",
+                            }
+                        )
 
                 elif right.type == "binary_expression" and self.flip():
                     if len(right.children) >= 3:
                         right_left = right.children[0]
-                        l_text = _safe_decode(source_bytes[left.start_byte - offset : left.end_byte - offset])
-                        op_text = _safe_decode(source_bytes[operator.start_byte - offset : operator.end_byte - offset])
-                        rl_text = _safe_decode(source_bytes[right_left.start_byte - offset : right_left.end_byte - offset])
-                        changes.append({
-                            "start": n.start_byte - offset,
-                            "end": n.end_byte - offset,
-                            "replacement": f"{l_text} {op_text} {rl_text}",
-                        })
+                        l_text = _safe_decode(
+                            source_bytes[
+                                left.start_byte - offset : left.end_byte - offset
+                            ]
+                        )
+                        op_text = _safe_decode(
+                            source_bytes[
+                                operator.start_byte - offset : operator.end_byte
+                                - offset
+                            ]
+                        )
+                        rl_text = _safe_decode(
+                            source_bytes[
+                                right_left.start_byte - offset : right_left.end_byte
+                                - offset
+                            ]
+                        )
+                        changes.append(
+                            {
+                                "start": n.start_byte - offset,
+                                "end": n.end_byte - offset,
+                                "replacement": f"{l_text} {op_text} {rl_text}",
+                            }
+                        )
 
             for child in n.children:
                 collect_chains(child)
@@ -420,24 +472,32 @@ class AugmentedAssignmentSwapModifier(PhpProceduralModifier):
         def collect_augmented_assignments(n):
             if n.type == "augmented_assignment_expression":
                 for child in n.children:
-                    op_text = source_bytes[child.start_byte - offset : child.end_byte - offset].decode("utf-8")
+                    op_text = source_bytes[
+                        child.start_byte - offset : child.end_byte - offset
+                    ].decode("utf-8")
                     if op_text in aug_assign_swaps and self.flip():
-                        changes.append({
-                            "start": child.start_byte - offset,
-                            "end": child.end_byte - offset,
-                            "new_op": aug_assign_swaps[op_text],
-                        })
+                        changes.append(
+                            {
+                                "start": child.start_byte - offset,
+                                "end": child.end_byte - offset,
+                                "new_op": aug_assign_swaps[op_text],
+                            }
+                        )
                         break
 
             elif n.type == "update_expression":
                 for child in n.children:
-                    op_text = source_bytes[child.start_byte - offset : child.end_byte - offset].decode("utf-8")
+                    op_text = source_bytes[
+                        child.start_byte - offset : child.end_byte - offset
+                    ].decode("utf-8")
                     if op_text in update_swaps and self.flip():
-                        changes.append({
-                            "start": child.start_byte - offset,
-                            "end": child.end_byte - offset,
-                            "new_op": update_swaps[op_text],
-                        })
+                        changes.append(
+                            {
+                                "start": child.start_byte - offset,
+                                "end": child.end_byte - offset,
+                                "new_op": update_swaps[op_text],
+                            }
+                        )
                         break
 
             for child in n.children:
@@ -469,7 +529,9 @@ class TernaryOperatorSwapModifier(PhpProceduralModifier):
     def modify(self, code_entity: CodeEntity) -> BugRewrite:
         tree, offset = php_parse(code_entity.src_code)
 
-        modified_code = self._modify_ternary(code_entity.src_code, tree.root_node, offset)
+        modified_code = self._modify_ternary(
+            code_entity.src_code, tree.root_node, offset
+        )
 
         if modified_code == code_entity.src_code:
             return None
@@ -494,18 +556,22 @@ class TernaryOperatorSwapModifier(PhpProceduralModifier):
                     alternative = content_children[2]
 
                     if self.flip():
-                        mod_type = self.rand.choice(["swap_branches", "negate_condition"])
-                        changes.append({
-                            "start": n.start_byte - offset,
-                            "end": n.end_byte - offset,
-                            "cond_start": condition.start_byte - offset,
-                            "cond_end": condition.end_byte - offset,
-                            "cons_start": consequent.start_byte - offset,
-                            "cons_end": consequent.end_byte - offset,
-                            "alt_start": alternative.start_byte - offset,
-                            "alt_end": alternative.end_byte - offset,
-                            "mod_type": mod_type,
-                        })
+                        mod_type = self.rand.choice(
+                            ["swap_branches", "negate_condition"]
+                        )
+                        changes.append(
+                            {
+                                "start": n.start_byte - offset,
+                                "end": n.end_byte - offset,
+                                "cond_start": condition.start_byte - offset,
+                                "cond_end": condition.end_byte - offset,
+                                "cons_start": consequent.start_byte - offset,
+                                "cons_end": consequent.end_byte - offset,
+                                "alt_start": alternative.start_byte - offset,
+                                "alt_end": alternative.end_byte - offset,
+                                "mod_type": mod_type,
+                            }
+                        )
 
             for child in n.children:
                 collect_ternary_ops(child)
@@ -517,9 +583,15 @@ class TernaryOperatorSwapModifier(PhpProceduralModifier):
 
         modified_source = source_bytes
         for change in reversed(changes):
-            cond_text = _safe_decode(source_bytes[change["cond_start"] : change["cond_end"]])
-            cons_text = _safe_decode(source_bytes[change["cons_start"] : change["cons_end"]])
-            alt_text = _safe_decode(source_bytes[change["alt_start"] : change["alt_end"]])
+            cond_text = _safe_decode(
+                source_bytes[change["cond_start"] : change["cond_end"]]
+            )
+            cons_text = _safe_decode(
+                source_bytes[change["cons_start"] : change["cons_end"]]
+            )
+            alt_text = _safe_decode(
+                source_bytes[change["alt_start"] : change["alt_end"]]
+            )
 
             if change["mod_type"] == "swap_branches":
                 new_ternary = f"{cond_text} ? {alt_text} : {cons_text}"
@@ -545,7 +617,9 @@ class FunctionArgumentSwapModifier(PhpProceduralModifier):
     def modify(self, code_entity: CodeEntity) -> BugRewrite:
         tree, offset = php_parse(code_entity.src_code)
 
-        modified_code = self._swap_arguments(code_entity.src_code, tree.root_node, offset)
+        modified_code = self._swap_arguments(
+            code_entity.src_code, tree.root_node, offset
+        )
 
         if modified_code == code_entity.src_code:
             return None
@@ -561,7 +635,11 @@ class FunctionArgumentSwapModifier(PhpProceduralModifier):
         source_bytes = source_code.encode("utf-8")
 
         def collect_function_calls(n):
-            if n.type in ["function_call_expression", "member_call_expression", "scoped_call_expression"]:
+            if n.type in [
+                "function_call_expression",
+                "member_call_expression",
+                "scoped_call_expression",
+            ]:
                 args_node = None
                 for child in n.children:
                     if child.type == "arguments":
@@ -569,16 +647,23 @@ class FunctionArgumentSwapModifier(PhpProceduralModifier):
                         break
 
                 if args_node:
-                    args = [c for c in args_node.children if c.type not in ["(", ")", ","]]
+                    args = [
+                        c for c in args_node.children if c.type not in ["(", ")", ","]
+                    ]
 
                     if len(args) >= 2 and self.flip():
                         swap_idx = self.rand.randint(0, len(args) - 2)
-                        changes.append({
-                            "args_start": args_node.start_byte - offset,
-                            "args_end": args_node.end_byte - offset,
-                            "args": [(a.start_byte - offset, a.end_byte - offset) for a in args],
-                            "swap_idx": swap_idx,
-                        })
+                        changes.append(
+                            {
+                                "args_start": args_node.start_byte - offset,
+                                "args_end": args_node.end_byte - offset,
+                                "args": [
+                                    (a.start_byte - offset, a.end_byte - offset)
+                                    for a in args
+                                ],
+                                "swap_idx": swap_idx,
+                            }
+                        )
 
             for child in n.children:
                 collect_function_calls(child)

--- a/swesmith/bug_gen/procedural/php/remove.py
+++ b/swesmith/bug_gen/procedural/php/remove.py
@@ -65,7 +65,9 @@ class RemoveConditionalModifier(PhpProceduralModifier):
     def modify(self, code_entity: CodeEntity) -> BugRewrite:
         tree, offset = php_parse(code_entity.src_code)
 
-        modified_code = self._remove_conditionals(code_entity.src_code, tree.root_node, offset)
+        modified_code = self._remove_conditionals(
+            code_entity.src_code, tree.root_node, offset
+        )
 
         if modified_code == code_entity.src_code:
             return None
@@ -108,7 +110,9 @@ class RemoveAssignmentModifier(PhpProceduralModifier):
     def modify(self, code_entity: CodeEntity) -> BugRewrite:
         tree, offset = php_parse(code_entity.src_code)
 
-        modified_code = self._remove_assignments(code_entity.src_code, tree.root_node, offset)
+        modified_code = self._remove_assignments(
+            code_entity.src_code, tree.root_node, offset
+        )
 
         if modified_code == code_entity.src_code:
             return None
@@ -129,7 +133,9 @@ class RemoveAssignmentModifier(PhpProceduralModifier):
             ]:
                 if self.flip():
                     if n.parent and n.parent.type == "expression_statement":
-                        removals.append((n.parent.start_byte - offset, n.parent.end_byte - offset))
+                        removals.append(
+                            (n.parent.start_byte - offset, n.parent.end_byte - offset)
+                        )
                     else:
                         removals.append((n.start_byte - offset, n.end_byte - offset))
             for child in n.children:
@@ -142,7 +148,11 @@ class RemoveAssignmentModifier(PhpProceduralModifier):
 
         modified_source = source_code
         for start, end in reversed(removals):
-            while end < len(modified_source) and modified_source[end] in [" ", "\t", ";"]:
+            while end < len(modified_source) and modified_source[end] in [
+                " ",
+                "\t",
+                ";",
+            ]:
                 end += 1
             if end < len(modified_source) and modified_source[end] == "\n":
                 end += 1
@@ -162,7 +172,9 @@ class RemoveTernaryModifier(PhpProceduralModifier):
     def modify(self, code_entity: CodeEntity) -> BugRewrite:
         tree, offset = php_parse(code_entity.src_code)
 
-        modified_code = self._remove_ternary(code_entity.src_code, tree.root_node, offset)
+        modified_code = self._remove_ternary(
+            code_entity.src_code, tree.root_node, offset
+        )
 
         if modified_code == code_entity.src_code:
             return None
@@ -187,12 +199,14 @@ class RemoveTernaryModifier(PhpProceduralModifier):
                     if self.flip():
                         keep_consequent = self.rand.choice([True, False])
                         replacement = consequent if keep_consequent else alternative
-                        changes.append({
-                            "start": n.start_byte - offset,
-                            "end": n.end_byte - offset,
-                            "rep_start": replacement.start_byte - offset,
-                            "rep_end": replacement.end_byte - offset,
-                        })
+                        changes.append(
+                            {
+                                "start": n.start_byte - offset,
+                                "end": n.end_byte - offset,
+                                "rep_start": replacement.start_byte - offset,
+                                "rep_end": replacement.end_byte - offset,
+                            }
+                        )
 
             for child in n.children:
                 collect_ternary_ops(child)

--- a/swesmith/bug_gen/procedural/php/remove.py
+++ b/swesmith/bug_gen/procedural/php/remove.py
@@ -1,0 +1,215 @@
+"""
+PHP remove modifiers for procedural bug generation using tree-sitter.
+"""
+
+from swesmith.bug_gen.procedural.base import CommonPMs
+from swesmith.bug_gen.procedural.php.base import PhpProceduralModifier, php_parse
+from swesmith.constants import BugRewrite, CodeEntity, CodeProperty
+
+
+class RemoveLoopModifier(PhpProceduralModifier):
+    """Remove loop statements (for, foreach, while, do-while)"""
+
+    explanation: str = CommonPMs.REMOVE_LOOP.explanation
+    name: str = CommonPMs.REMOVE_LOOP.name
+    conditions: list = CommonPMs.REMOVE_LOOP.conditions
+
+    def modify(self, code_entity: CodeEntity) -> BugRewrite:
+        tree, offset = php_parse(code_entity.src_code)
+
+        modified_code = self._remove_loops(code_entity.src_code, tree.root_node, offset)
+
+        if modified_code == code_entity.src_code:
+            return None
+
+        return BugRewrite(
+            rewrite=modified_code,
+            explanation=self.explanation,
+            strategy=self.name,
+        )
+
+    def _remove_loops(self, source_code: str, node, offset: int) -> str:
+        removals = []
+
+        def collect_loops(n):
+            if n.type in [
+                "for_statement",
+                "foreach_statement",
+                "while_statement",
+                "do_statement",
+            ]:
+                if self.flip():
+                    removals.append((n.start_byte - offset, n.end_byte - offset))
+            for child in n.children:
+                collect_loops(child)
+
+        collect_loops(node)
+
+        if not removals:
+            return source_code
+
+        modified_source = source_code
+        for start, end in reversed(removals):
+            modified_source = modified_source[:start] + modified_source[end:]
+
+        return modified_source
+
+
+class RemoveConditionalModifier(PhpProceduralModifier):
+    """Remove conditional statements (if statements)"""
+
+    explanation: str = CommonPMs.REMOVE_CONDITIONAL.explanation
+    name: str = CommonPMs.REMOVE_CONDITIONAL.name
+    conditions: list = CommonPMs.REMOVE_CONDITIONAL.conditions
+
+    def modify(self, code_entity: CodeEntity) -> BugRewrite:
+        tree, offset = php_parse(code_entity.src_code)
+
+        modified_code = self._remove_conditionals(code_entity.src_code, tree.root_node, offset)
+
+        if modified_code == code_entity.src_code:
+            return None
+
+        return BugRewrite(
+            rewrite=modified_code,
+            explanation=self.explanation,
+            strategy=self.name,
+        )
+
+    def _remove_conditionals(self, source_code: str, node, offset: int) -> str:
+        removals = []
+
+        def collect_conditionals(n):
+            if n.type == "if_statement":
+                if self.flip():
+                    removals.append((n.start_byte - offset, n.end_byte - offset))
+            for child in n.children:
+                collect_conditionals(child)
+
+        collect_conditionals(node)
+
+        if not removals:
+            return source_code
+
+        modified_source = source_code
+        for start, end in reversed(removals):
+            modified_source = modified_source[:start] + modified_source[end:]
+
+        return modified_source
+
+
+class RemoveAssignmentModifier(PhpProceduralModifier):
+    """Remove assignment statements"""
+
+    explanation: str = CommonPMs.REMOVE_ASSIGNMENT.explanation
+    name: str = CommonPMs.REMOVE_ASSIGNMENT.name
+    conditions: list = CommonPMs.REMOVE_ASSIGNMENT.conditions
+
+    def modify(self, code_entity: CodeEntity) -> BugRewrite:
+        tree, offset = php_parse(code_entity.src_code)
+
+        modified_code = self._remove_assignments(code_entity.src_code, tree.root_node, offset)
+
+        if modified_code == code_entity.src_code:
+            return None
+
+        return BugRewrite(
+            rewrite=modified_code,
+            explanation=self.explanation,
+            strategy=self.name,
+        )
+
+    def _remove_assignments(self, source_code: str, node, offset: int) -> str:
+        removals = []
+
+        def collect_assignments(n):
+            if n.type in [
+                "assignment_expression",
+                "augmented_assignment_expression",
+            ]:
+                if self.flip():
+                    if n.parent and n.parent.type == "expression_statement":
+                        removals.append((n.parent.start_byte - offset, n.parent.end_byte - offset))
+                    else:
+                        removals.append((n.start_byte - offset, n.end_byte - offset))
+            for child in n.children:
+                collect_assignments(child)
+
+        collect_assignments(node)
+
+        if not removals:
+            return source_code
+
+        modified_source = source_code
+        for start, end in reversed(removals):
+            while end < len(modified_source) and modified_source[end] in [" ", "\t", ";"]:
+                end += 1
+            if end < len(modified_source) and modified_source[end] == "\n":
+                end += 1
+
+            modified_source = modified_source[:start] + modified_source[end:]
+
+        return modified_source
+
+
+class RemoveTernaryModifier(PhpProceduralModifier):
+    """Remove ternary expressions by replacing with just one branch."""
+
+    explanation: str = "A ternary conditional expression may be missing - only one branch is being used."
+    name: str = "func_pm_remove_ternary"
+    conditions: list = [CodeProperty.IS_FUNCTION, CodeProperty.HAS_TERNARY]
+
+    def modify(self, code_entity: CodeEntity) -> BugRewrite:
+        tree, offset = php_parse(code_entity.src_code)
+
+        modified_code = self._remove_ternary(code_entity.src_code, tree.root_node, offset)
+
+        if modified_code == code_entity.src_code:
+            return None
+
+        return BugRewrite(
+            rewrite=modified_code,
+            explanation=self.explanation,
+            strategy=self.name,
+        )
+
+    def _remove_ternary(self, source_code: str, node, offset: int) -> str:
+        changes = []
+        source_bytes = source_code.encode("utf-8")
+
+        def collect_ternary_ops(n):
+            if n.type == "conditional_expression" and len(n.children) >= 5:
+                content_children = [c for c in n.children if c.type not in ["?", ":"]]
+                if len(content_children) >= 3:
+                    consequent = content_children[1]
+                    alternative = content_children[2]
+
+                    if self.flip():
+                        keep_consequent = self.rand.choice([True, False])
+                        replacement = consequent if keep_consequent else alternative
+                        changes.append({
+                            "start": n.start_byte - offset,
+                            "end": n.end_byte - offset,
+                            "rep_start": replacement.start_byte - offset,
+                            "rep_end": replacement.end_byte - offset,
+                        })
+
+            for child in n.children:
+                collect_ternary_ops(child)
+
+        collect_ternary_ops(node)
+
+        if not changes:
+            return source_code
+
+        modified_source = source_bytes
+        for change in reversed(changes):
+            replacement_text = source_bytes[change["rep_start"] : change["rep_end"]]
+
+            modified_source = (
+                modified_source[: change["start"]]
+                + replacement_text
+                + modified_source[change["end"] :]
+            )
+
+        return modified_source.decode("utf-8")

--- a/swesmith/bug_gen/procedural/php/remove.py
+++ b/swesmith/bug_gen/procedural/php/remove.py
@@ -127,19 +127,23 @@ class RemoveAssignmentModifier(PhpProceduralModifier):
         removals = []
 
         def collect_assignments(n):
+            matched = False
             if n.type in [
                 "assignment_expression",
                 "augmented_assignment_expression",
+                "reference_assignment_expression",
             ]:
                 if self.flip():
+                    matched = True
                     if n.parent and n.parent.type == "expression_statement":
                         removals.append(
                             (n.parent.start_byte - offset, n.parent.end_byte - offset)
                         )
                     else:
                         removals.append((n.start_byte - offset, n.end_byte - offset))
-            for child in n.children:
-                collect_assignments(child)
+            if not matched:
+                for child in n.children:
+                    collect_assignments(child)
 
         collect_assignments(node)
 
@@ -190,13 +194,16 @@ class RemoveTernaryModifier(PhpProceduralModifier):
         source_bytes = source_code.encode("utf-8")
 
         def collect_ternary_ops(n):
-            if n.type == "conditional_expression" and len(n.children) >= 5:
+            matched = False
+            if n.type == "conditional_expression":
                 content_children = [c for c in n.children if c.type not in ["?", ":"]]
                 if len(content_children) >= 3:
+                    # Standard ternary: $cond ? $then : $else
                     consequent = content_children[1]
                     alternative = content_children[2]
 
                     if self.flip():
+                        matched = True
                         keep_consequent = self.rand.choice([True, False])
                         replacement = consequent if keep_consequent else alternative
                         changes.append(
@@ -207,9 +214,27 @@ class RemoveTernaryModifier(PhpProceduralModifier):
                                 "rep_end": replacement.end_byte - offset,
                             }
                         )
+                elif len(content_children) == 2:
+                    # Elvis operator: $cond ?: $else
+                    condition = content_children[0]
+                    alternative = content_children[1]
 
-            for child in n.children:
-                collect_ternary_ops(child)
+                    if self.flip():
+                        matched = True
+                        keep_condition = self.rand.choice([True, False])
+                        replacement = condition if keep_condition else alternative
+                        changes.append(
+                            {
+                                "start": n.start_byte - offset,
+                                "end": n.end_byte - offset,
+                                "rep_start": replacement.start_byte - offset,
+                                "rep_end": replacement.end_byte - offset,
+                            }
+                        )
+
+            if not matched:
+                for child in n.children:
+                    collect_ternary_ops(child)
 
         collect_ternary_ops(node)
 

--- a/swesmith/profiles/php.py
+++ b/swesmith/profiles/php.py
@@ -22,42 +22,18 @@ class PhpProfile(RepoProfile):
     org_dh: str = "swebench"
     test_cmd: str = "vendor/bin/phpunit --testdox --colors=never"
     exts: list[str] = field(default_factory=lambda: [".php"])
-    _test_name_to_files_cache: dict[str, set[str]] = field(
-        default=None, init=False, repr=False
-    )
+    _fqcn_to_file_cache: dict[str, str] = field(default=None, init=False, repr=False)
 
-    @staticmethod
-    def _testdox_name(method_name: str) -> str:
-        """Convert a PHP test method name to its testdox description.
+    def _build_fqcn_to_file_map(self) -> dict[str, str]:
+        """Build a mapping from fully-qualified class names to file paths.
 
-        PHPUnit strips the 'test' prefix, then converts camelCase to
-        space-separated lowercase words (first word capitalized).
-        e.g. testGetServerVersion -> Get server version
-             testFetchAssociative -> Fetch associative
-        """
-        name = method_name
-        if name.startswith("test"):
-            name = name[4:]
-        # Insert space before uppercase letters (camelCase -> words)
-        name = re.sub(r"([a-z])([A-Z])", r"\1 \2", name)
-        name = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", name)
-        # PHPUnit lowercases everything then capitalizes first letter
-        words = name.split()
-        if words:
-            words = [words[0]] + [w.lower() for w in words[1:]]
-            name = " ".join(words)
-        return name
-
-    def _build_test_name_to_files_map(self) -> dict[str, set[str]]:
-        """Build a mapping from testdox names to test file paths.
-
-        Scans PHP test files for method names starting with 'test' and
-        converts them to their testdox representation.
+        Scans PHP test files for namespace + class declarations.
         """
         dest, cloned = self.clone()
-        name_to_files: dict[str, set[str]] = {}
+        fqcn_to_file: dict[str, str] = {}
 
-        test_method_re = re.compile(r"(?:public\s+)?function\s+(test[A-Z]\w*)\s*\(")
+        namespace_re = re.compile(r"^\s*namespace\s+([\w\\]+)\s*;")
+        class_re = re.compile(r"^\s*(?:abstract\s+|final\s+)?class\s+(\w+)")
 
         for dirpath, _, filenames in os.walk(dest):
             if "vendor" in dirpath.split(os.sep):
@@ -65,7 +41,6 @@ class PhpProfile(RepoProfile):
             for fname in filenames:
                 if not fname.endswith(".php"):
                     continue
-                # PHPUnit convention: test files end with Test.php or are in tests/ dir
                 parts = dirpath.split(os.sep)
                 in_test_dir = any(
                     p in ("test", "tests", "Test", "Tests") for p in parts
@@ -83,36 +58,49 @@ class PhpProfile(RepoProfile):
                 except (OSError, UnicodeDecodeError):
                     continue
 
-                for match in test_method_re.finditer(content):
-                    testdox = self._testdox_name(match.group(1))
-                    name_to_files.setdefault(testdox, set()).add(relative_path)
+                namespace = ""
+                for line in content.split("\n"):
+                    ns_match = namespace_re.match(line)
+                    if ns_match:
+                        namespace = ns_match.group(1)
+                        break
+
+                for line in content.split("\n"):
+                    cls_match = class_re.match(line)
+                    if cls_match:
+                        fqcn = cls_match.group(1)
+                        if namespace:
+                            fqcn = f"{namespace}\\{fqcn}"
+                        fqcn_to_file[fqcn] = relative_path
+                        break
 
         if cloned:
             shutil.rmtree(dest)
-        return name_to_files
+        return fqcn_to_file
 
     def get_test_files(self, instance: dict) -> tuple[list[str], list[str]]:
         assert FAIL_TO_PASS in instance and PASS_TO_PASS in instance, (
             f"Instance {instance[KEY_INSTANCE_ID]} missing required keys {FAIL_TO_PASS} or {PASS_TO_PASS}"
         )
 
-        if self._test_name_to_files_cache is None:
+        if self._fqcn_to_file_cache is None:
             with self._lock:
-                if self._test_name_to_files_cache is None:
-                    self._test_name_to_files_cache = (
-                        self._build_test_name_to_files_map()
+                if self._fqcn_to_file_cache is None:
+                    self._fqcn_to_file_cache = (
+                        self._build_fqcn_to_file_map()
                     )
 
-        f2p_files: set[str] = set()
-        for test_name in instance[FAIL_TO_PASS]:
-            if test_name in self._test_name_to_files_cache:
-                f2p_files.update(self._test_name_to_files_cache[test_name])
+        def _resolve_files(test_names: list[str]) -> set[str]:
+            files: set[str] = set()
+            for test_name in test_names:
+                # test_name is "FQCN::Testdox name" — extract the FQCN
+                fqcn = test_name.split("::")[0] if "::" in test_name else test_name
+                if fqcn in self._fqcn_to_file_cache:
+                    files.add(self._fqcn_to_file_cache[fqcn])
+            return files
 
-        p2p_files: set[str] = set()
-        for test_name in instance[PASS_TO_PASS]:
-            if test_name in self._test_name_to_files_cache:
-                p2p_files.update(self._test_name_to_files_cache[test_name])
-
+        f2p_files = _resolve_files(instance[FAIL_TO_PASS])
+        p2p_files = _resolve_files(instance[PASS_TO_PASS])
         return list(f2p_files), list(p2p_files)
 
 
@@ -144,12 +132,23 @@ RUN composer install
 
 
 def parse_log_phpunit_testdox(log: str) -> dict[str, str]:
-    """Parse PHPUnit --testdox output format."""
+    """Parse PHPUnit --testdox output format.
+
+    Captures class headers like:
+        Connection (Doctrine\\DBAL\\Tests\\ConnectionTest)
+    and qualifies test names as 'FQCN::Testdox name'.
+    """
     test_status_map = {}
+    class_header = re.compile(r"^.+\((.+)\)\s*$")
     passed_pattern = re.compile(r"^\s*✔\s*(.+)$")
     failed_pattern = re.compile(r"^\s*✘\s*(.+)$")
     skipped_pattern = re.compile(r"^\s*↩\s*(.+)$")
+    current_class = None
     for line in log.split("\n"):
+        cm = class_header.match(line)
+        if cm:
+            current_class = cm.group(1).strip()
+            continue
         for pattern, status in (
             (passed_pattern, TestStatus.PASSED.value),
             (failed_pattern, TestStatus.FAILED.value),
@@ -158,43 +157,12 @@ def parse_log_phpunit_testdox(log: str) -> dict[str, str]:
             match = pattern.match(line)
             if match:
                 test_name = match.group(1).strip()
+                if current_class:
+                    test_name = f"{current_class}::{test_name}"
                 test_status_map[test_name] = status
                 break
     return test_status_map
 
-
-def parse_log_phpunit_verbose(log: str) -> dict[str, str]:
-    """Parse PHPUnit --verbose (non-testdox) output format.
-
-    Matches lines like:
-    ✓ testMethodName
-    ✗ testMethodName
-    Or standard verbose format:
-    OK (42 tests, 100 assertions)
-    FAILURES!
-    Tests: 42, Assertions: 100, Failures: 2.
-    """
-    test_status_map = {}
-    # Match individual test results in verbose mode
-    # Format: "Test\\Namespace\\Class::testMethod"
-    passed = re.compile(r"^\s*✓\s*(.+)$")
-    failed = re.compile(r"^\s*✗\s*(.+)$")
-    # Also match standard PHPUnit output lines
-    std_pass = re.compile(r"^ok \d+ - (.+)$", re.IGNORECASE)
-    std_fail = re.compile(r"^not ok \d+ - (.+)$", re.IGNORECASE)
-    for line in log.split("\n"):
-        for pattern, status in (
-            (passed, TestStatus.PASSED.value),
-            (failed, TestStatus.FAILED.value),
-            (std_pass, TestStatus.PASSED.value),
-            (std_fail, TestStatus.FAILED.value),
-        ):
-            match = pattern.match(line)
-            if match:
-                test_name = match.group(1).strip()
-                test_status_map[test_name] = status
-                break
-    return test_status_map
 
 
 @dataclass

--- a/swesmith/profiles/php.py
+++ b/swesmith/profiles/php.py
@@ -117,7 +117,7 @@ class PhpProfile(RepoProfile):
 
 
 @dataclass
-class Dbal(PhpProfile):
+class Dbalacb68b38(PhpProfile):
     owner: str = "doctrine"
     repo: str = "dbal"
     commit: str = "acb68b388b2577bb211bb26dc22d20a8ad93d97d"

--- a/swesmith/profiles/php.py
+++ b/swesmith/profiles/php.py
@@ -57,9 +57,7 @@ class PhpProfile(RepoProfile):
         dest, cloned = self.clone()
         name_to_files: dict[str, set[str]] = {}
 
-        test_method_re = re.compile(
-            r"(?:public\s+)?function\s+(test[A-Z]\w*)\s*\("
-        )
+        test_method_re = re.compile(r"(?:public\s+)?function\s+(test[A-Z]\w*)\s*\(")
 
         for dirpath, _, filenames in os.walk(dest):
             if "vendor" in dirpath.split(os.sep):

--- a/swesmith/profiles/php.py
+++ b/swesmith/profiles/php.py
@@ -1,7 +1,14 @@
+import os
 import re
+import shutil
 
 from dataclasses import dataclass, field
-from swebench.harness.constants import TestStatus
+from swebench.harness.constants import (
+    FAIL_TO_PASS,
+    PASS_TO_PASS,
+    KEY_INSTANCE_ID,
+    TestStatus,
+)
 from swesmith.constants import ENV_NAME
 from swesmith.profiles.base import RepoProfile, registry
 
@@ -15,6 +22,100 @@ class PhpProfile(RepoProfile):
     org_dh: str = "swebench"
     test_cmd: str = "vendor/bin/phpunit --testdox --colors=never"
     exts: list[str] = field(default_factory=lambda: [".php"])
+    _test_name_to_files_cache: dict[str, set[str]] = field(
+        default=None, init=False, repr=False
+    )
+
+    @staticmethod
+    def _testdox_name(method_name: str) -> str:
+        """Convert a PHP test method name to its testdox description.
+
+        PHPUnit strips the 'test' prefix, then converts camelCase to
+        space-separated lowercase words (first word capitalized).
+        e.g. testGetServerVersion -> Get server version
+             testFetchAssociative -> Fetch associative
+        """
+        name = method_name
+        if name.startswith("test"):
+            name = name[4:]
+        # Insert space before uppercase letters (camelCase -> words)
+        name = re.sub(r"([a-z])([A-Z])", r"\1 \2", name)
+        name = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", name)
+        # PHPUnit lowercases everything then capitalizes first letter
+        words = name.split()
+        if words:
+            words = [words[0]] + [w.lower() for w in words[1:]]
+            name = " ".join(words)
+        return name
+
+    def _build_test_name_to_files_map(self) -> dict[str, set[str]]:
+        """Build a mapping from testdox names to test file paths.
+
+        Scans PHP test files for method names starting with 'test' and
+        converts them to their testdox representation.
+        """
+        dest, cloned = self.clone()
+        name_to_files: dict[str, set[str]] = {}
+
+        test_method_re = re.compile(
+            r"(?:public\s+)?function\s+(test[A-Z]\w*)\s*\("
+        )
+
+        for dirpath, _, filenames in os.walk(dest):
+            if "vendor" in dirpath.split(os.sep):
+                continue
+            for fname in filenames:
+                if not fname.endswith(".php"):
+                    continue
+                # PHPUnit convention: test files end with Test.php or are in tests/ dir
+                parts = dirpath.split(os.sep)
+                in_test_dir = any(
+                    p in ("test", "tests", "Test", "Tests") for p in parts
+                )
+                is_test_named = fname.endswith("Test.php") or fname.startswith("test")
+                if not in_test_dir and not is_test_named:
+                    continue
+
+                full_path = os.path.join(dirpath, fname)
+                relative_path = os.path.relpath(full_path, dest)
+
+                try:
+                    with open(full_path, "r", encoding="utf-8") as f:
+                        content = f.read()
+                except (OSError, UnicodeDecodeError):
+                    continue
+
+                for match in test_method_re.finditer(content):
+                    testdox = self._testdox_name(match.group(1))
+                    name_to_files.setdefault(testdox, set()).add(relative_path)
+
+        if cloned:
+            shutil.rmtree(dest)
+        return name_to_files
+
+    def get_test_files(self, instance: dict) -> tuple[list[str], list[str]]:
+        assert FAIL_TO_PASS in instance and PASS_TO_PASS in instance, (
+            f"Instance {instance[KEY_INSTANCE_ID]} missing required keys {FAIL_TO_PASS} or {PASS_TO_PASS}"
+        )
+
+        if self._test_name_to_files_cache is None:
+            with self._lock:
+                if self._test_name_to_files_cache is None:
+                    self._test_name_to_files_cache = (
+                        self._build_test_name_to_files_map()
+                    )
+
+        f2p_files: set[str] = set()
+        for test_name in instance[FAIL_TO_PASS]:
+            if test_name in self._test_name_to_files_cache:
+                f2p_files.update(self._test_name_to_files_cache[test_name])
+
+        p2p_files: set[str] = set()
+        for test_name in instance[PASS_TO_PASS]:
+            if test_name in self._test_name_to_files_cache:
+                p2p_files.update(self._test_name_to_files_cache[test_name])
+
+        return list(f2p_files), list(p2p_files)
 
 
 @dataclass
@@ -140,78 +241,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 RUN git clone https://github.com/{self.mirror_name} /{ENV_NAME}
 WORKDIR /{ENV_NAME}
 RUN composer install --ignore-platform-req=ext-mongodb
-"""
-
-    def log_parser(self, log: str) -> dict[str, str]:
-        return parse_log_phpunit_testdox(log)
-
-
-@dataclass
-class PhpParser50f0d9c9(PhpProfile):
-    owner: str = "nikic"
-    repo: str = "PHP-Parser"
-    commit: str = "50f0d9c9d0e3cff1163c959c50aaaaa4a7115f08"
-
-    @property
-    def dockerfile(self):
-        return f"""FROM php:8.3
-RUN apt-get update && \
-    apt-get install -y git unzip && \
-    apt-get -y autoclean && \
-    rm -rf /var/lib/apt/lists/*
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN git clone https://github.com/{self.mirror_name} /{ENV_NAME}
-WORKDIR /{ENV_NAME}
-ENV COMPOSER_ROOT_VERSION=5.99.99
-RUN composer install --no-interaction
-"""
-
-    def log_parser(self, log: str) -> dict[str, str]:
-        return parse_log_phpunit_testdox(log)
-
-
-@dataclass
-class Carbon72ee09e5(PhpProfile):
-    owner: str = "briannesbitt"
-    repo: str = "Carbon"
-    commit: str = "72ee09e5ada27bd82d668ba30e877722251d8322"
-
-    @property
-    def dockerfile(self):
-        return f"""FROM php:8.3
-RUN apt-get update && \
-    apt-get install -y git unzip libxml2-dev libonig-dev && \
-    docker-php-ext-install mbstring xml dom && \
-    apt-get -y autoclean && \
-    rm -rf /var/lib/apt/lists/*
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN git clone https://github.com/{self.mirror_name} /{ENV_NAME}
-WORKDIR /{ENV_NAME}
-RUN composer install
-"""
-
-    def log_parser(self, log: str) -> dict[str, str]:
-        return parse_log_phpunit_testdox(log)
-
-
-@dataclass
-class PHPMailera80b3777(PhpProfile):
-    owner: str = "PHPMailer"
-    repo: str = "PHPMailer"
-    commit: str = "a80b3777e68939a8ca0c7c32b58fb87190499f54"
-
-    @property
-    def dockerfile(self):
-        return f"""FROM php:8.3
-RUN apt-get update && \
-    apt-get install -y git unzip libxml2-dev libzip-dev libonig-dev && \
-    docker-php-ext-install mbstring zip && \
-    apt-get -y autoclean && \
-    rm -rf /var/lib/apt/lists/*
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN git clone https://github.com/{self.mirror_name} /{ENV_NAME}
-WORKDIR /{ENV_NAME}
-RUN composer install
 """
 
     def log_parser(self, log: str) -> dict[str, str]:

--- a/swesmith/profiles/php.py
+++ b/swesmith/profiles/php.py
@@ -86,9 +86,7 @@ class PhpProfile(RepoProfile):
         if self._fqcn_to_file_cache is None:
             with self._lock:
                 if self._fqcn_to_file_cache is None:
-                    self._fqcn_to_file_cache = (
-                        self._build_fqcn_to_file_map()
-                    )
+                    self._fqcn_to_file_cache = self._build_fqcn_to_file_map()
 
         def _resolve_files(test_names: list[str]) -> set[str]:
             files: set[str] = set()
@@ -162,7 +160,6 @@ def parse_log_phpunit_testdox(log: str) -> dict[str, str]:
                 test_status_map[test_name] = status
                 break
     return test_status_map
-
 
 
 @dataclass

--- a/swesmith/profiles/php.py
+++ b/swesmith/profiles/php.py
@@ -12,6 +12,7 @@ class PhpProfile(RepoProfile):
     Profile for PHP repositories.
     """
 
+    org_dh: str = "swebench"
     test_cmd: str = "vendor/bin/phpunit --testdox --colors=never"
     exts: list[str] = field(default_factory=lambda: [".php"])
 
@@ -40,25 +41,184 @@ RUN composer install
 """
 
     def log_parser(self, log: str) -> dict[str, str]:
-        test_status_map = {}
-        passed_pattern = re.compile(r"^\s*✔\s*(.+)$")
-        failed_pattern = re.compile(r"^\s*✘\s*(.+)$")
-        skipped_pattern = re.compile(r"^\s*↩\s*(.+)$")
-        for line in log.split("\n"):
-            for pattern, status in (
-                (passed_pattern, TestStatus.PASSED.value),
-                (failed_pattern, TestStatus.FAILED.value),
-                (skipped_pattern, TestStatus.SKIPPED.value),
-            ):
-                match = pattern.match(line)
-                if match:
-                    test_name = match.group(1).strip()
-                    test_status_map[test_name] = status
-                    break
-        return test_status_map
+        return parse_log_phpunit_testdox(log)
 
 
-# Register all Rust profiles with the global registry
+def parse_log_phpunit_testdox(log: str) -> dict[str, str]:
+    """Parse PHPUnit --testdox output format."""
+    test_status_map = {}
+    passed_pattern = re.compile(r"^\s*✔\s*(.+)$")
+    failed_pattern = re.compile(r"^\s*✘\s*(.+)$")
+    skipped_pattern = re.compile(r"^\s*↩\s*(.+)$")
+    for line in log.split("\n"):
+        for pattern, status in (
+            (passed_pattern, TestStatus.PASSED.value),
+            (failed_pattern, TestStatus.FAILED.value),
+            (skipped_pattern, TestStatus.SKIPPED.value),
+        ):
+            match = pattern.match(line)
+            if match:
+                test_name = match.group(1).strip()
+                test_status_map[test_name] = status
+                break
+    return test_status_map
+
+
+def parse_log_phpunit_verbose(log: str) -> dict[str, str]:
+    """Parse PHPUnit --verbose (non-testdox) output format.
+
+    Matches lines like:
+    ✓ testMethodName
+    ✗ testMethodName
+    Or standard verbose format:
+    OK (42 tests, 100 assertions)
+    FAILURES!
+    Tests: 42, Assertions: 100, Failures: 2.
+    """
+    test_status_map = {}
+    # Match individual test results in verbose mode
+    # Format: "Test\\Namespace\\Class::testMethod"
+    passed = re.compile(r"^\s*✓\s*(.+)$")
+    failed = re.compile(r"^\s*✗\s*(.+)$")
+    # Also match standard PHPUnit output lines
+    std_pass = re.compile(r"^ok \d+ - (.+)$", re.IGNORECASE)
+    std_fail = re.compile(r"^not ok \d+ - (.+)$", re.IGNORECASE)
+    for line in log.split("\n"):
+        for pattern, status in (
+            (passed, TestStatus.PASSED.value),
+            (failed, TestStatus.FAILED.value),
+            (std_pass, TestStatus.PASSED.value),
+            (std_fail, TestStatus.FAILED.value),
+        ):
+            match = pattern.match(line)
+            if match:
+                test_name = match.group(1).strip()
+                test_status_map[test_name] = status
+                break
+    return test_status_map
+
+
+@dataclass
+class Guzzlefb92d95f(PhpProfile):
+    owner: str = "guzzle"
+    repo: str = "guzzle"
+    commit: str = "fb92d95f80a9da51bf8f2a5b26d8e8ea3b6d99ed"
+
+    @property
+    def dockerfile(self):
+        return f"""FROM php:8.3
+RUN apt-get update && \
+    apt-get install -y git unzip libcurl4-openssl-dev libzip-dev nodejs npm && \
+    docker-php-ext-install curl zip && \
+    apt-get -y autoclean && \
+    rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN git clone https://github.com/{self.mirror_name} /{ENV_NAME}
+WORKDIR /{ENV_NAME}
+RUN composer install
+"""
+
+    def log_parser(self, log: str) -> dict[str, str]:
+        return parse_log_phpunit_testdox(log)
+
+
+@dataclass
+class Monolog6db20ca0(PhpProfile):
+    owner: str = "Seldaek"
+    repo: str = "monolog"
+    commit: str = "6db20ca029219dd8de378cea8e32ee149399ef1b"
+
+    @property
+    def dockerfile(self):
+        return f"""FROM php:8.3
+RUN apt-get update && \
+    apt-get install -y git unzip libcurl4-openssl-dev && \
+    docker-php-ext-install curl sockets && \
+    apt-get -y autoclean && \
+    rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN git clone https://github.com/{self.mirror_name} /{ENV_NAME}
+WORKDIR /{ENV_NAME}
+RUN composer install --ignore-platform-req=ext-mongodb
+"""
+
+    def log_parser(self, log: str) -> dict[str, str]:
+        return parse_log_phpunit_testdox(log)
+
+
+@dataclass
+class PhpParser50f0d9c9(PhpProfile):
+    owner: str = "nikic"
+    repo: str = "PHP-Parser"
+    commit: str = "50f0d9c9d0e3cff1163c959c50aaaaa4a7115f08"
+
+    @property
+    def dockerfile(self):
+        return f"""FROM php:8.3
+RUN apt-get update && \
+    apt-get install -y git unzip && \
+    apt-get -y autoclean && \
+    rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN git clone https://github.com/{self.mirror_name} /{ENV_NAME}
+WORKDIR /{ENV_NAME}
+ENV COMPOSER_ROOT_VERSION=5.99.99
+RUN composer install --no-interaction
+"""
+
+    def log_parser(self, log: str) -> dict[str, str]:
+        return parse_log_phpunit_testdox(log)
+
+
+@dataclass
+class Carbon72ee09e5(PhpProfile):
+    owner: str = "briannesbitt"
+    repo: str = "Carbon"
+    commit: str = "72ee09e5ada27bd82d668ba30e877722251d8322"
+
+    @property
+    def dockerfile(self):
+        return f"""FROM php:8.3
+RUN apt-get update && \
+    apt-get install -y git unzip libxml2-dev libonig-dev && \
+    docker-php-ext-install mbstring xml dom && \
+    apt-get -y autoclean && \
+    rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN git clone https://github.com/{self.mirror_name} /{ENV_NAME}
+WORKDIR /{ENV_NAME}
+RUN composer install
+"""
+
+    def log_parser(self, log: str) -> dict[str, str]:
+        return parse_log_phpunit_testdox(log)
+
+
+@dataclass
+class PHPMailera80b3777(PhpProfile):
+    owner: str = "PHPMailer"
+    repo: str = "PHPMailer"
+    commit: str = "a80b3777e68939a8ca0c7c32b58fb87190499f54"
+
+    @property
+    def dockerfile(self):
+        return f"""FROM php:8.3
+RUN apt-get update && \
+    apt-get install -y git unzip libxml2-dev libzip-dev libonig-dev && \
+    docker-php-ext-install mbstring zip && \
+    apt-get -y autoclean && \
+    rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN git clone https://github.com/{self.mirror_name} /{ENV_NAME}
+WORKDIR /{ENV_NAME}
+RUN composer install
+"""
+
+    def log_parser(self, log: str) -> dict[str, str]:
+        return parse_log_phpunit_testdox(log)
+
+
+# Register all PHP profiles with the global registry
 for name, obj in list(globals().items()):
     if (
         isinstance(obj, type)

--- a/tests/bug_gen/adapters/test_php.py
+++ b/tests/bug_gen/adapters/test_php.py
@@ -230,19 +230,14 @@ def test_php_entity_has_lambda_arrow(tmp_path):
 
 
 def test_php_entity_has_lambda_anonymous(tmp_path):
-    """anonymous_function_creation_expression check in adapter.
-    tree-sitter-php uses 'anonymous_function' node type, so this won't
-    currently trigger HAS_LAMBDA. Verify it doesn't crash."""
+    """Anonymous function (closure) should trigger HAS_LAMBDA."""
     src = """function foo() {
     $fn = function($x) { return $x * 2; };
     return $fn(5);
 }"""
     entities = _get_entities(tmp_path, src)
     assert len(entities) >= 1
-    # The adapter checks for 'anonymous_function_creation_expression' but
-    # tree-sitter uses 'anonymous_function', so this tag won't be set.
-    # Arrow functions (fn =>) do work correctly.
-    assert CodeProperty.HAS_LAMBDA not in entities[0]._tags
+    assert CodeProperty.HAS_LAMBDA in entities[0]._tags
 
 
 def test_php_entity_has_arithmetic(tmp_path):

--- a/tests/bug_gen/adapters/test_php.py
+++ b/tests/bug_gen/adapters/test_php.py
@@ -1,6 +1,5 @@
-from swesmith.bug_gen.adapters.php import (
-    get_entities_from_file_php,
-)
+from swesmith.bug_gen.adapters.php import get_entities_from_file_php
+from swesmith.constants import CodeProperty
 
 
 def test_get_entities_from_file_php(test_file_php):
@@ -128,3 +127,203 @@ def test_php_entity_multi_line_signature(tmp_path):
         entity.signature
         == "function multi_line_function(\n    $param1,\n    $param2\n)"
     )
+
+
+PHP_PREFIX = "<?php\n"
+
+
+def _get_entities(tmp_path, src):
+    test_file = tmp_path / "test.php"
+    test_file.write_text(PHP_PREFIX + src, encoding="utf-8")
+    entities = []
+    get_entities_from_file_php(entities, str(test_file))
+    return entities
+
+
+def test_php_entity_class_name(tmp_path):
+    """Test that class_declaration entities return the class name."""
+    src = """class MyClass {
+    public function doStuff() {
+        return 42;
+    }
+}"""
+    entities = _get_entities(tmp_path, src)
+    class_entity = [e for e in entities if e.node.type == "class_declaration"]
+    assert len(class_entity) >= 1
+    assert class_entity[0].name == "MyClass"
+
+
+def test_php_entity_method_name(tmp_path):
+    """Test that method_declaration entities return ClassName::methodName."""
+    src = """class Calculator {
+    public function testAdd() {
+        return 1 + 2;
+    }
+}"""
+    entities = _get_entities(tmp_path, src)
+    method_entities = [e for e in entities if e.node.type == "method_declaration"]
+    assert len(method_entities) >= 1
+    assert method_entities[0].name == "Calculator::testAdd"
+
+
+def test_php_entity_unknown_name(tmp_path):
+    """Test that an unknown node type returns 'unknown'."""
+    src = """function normal() {
+    return 1;
+}"""
+    entities = _get_entities(tmp_path, src)
+    assert len(entities) >= 1
+    # The function entity should have a real name, but let's verify the fallback
+    entity = entities[0]
+    assert entity.name == "normal"
+
+
+def test_php_entity_has_switch(tmp_path):
+    src = """function foo($x) {
+    switch ($x) {
+        case 1:
+            return "one";
+        case 2:
+            return "two";
+        default:
+            return "other";
+    }
+}"""
+    entities = _get_entities(tmp_path, src)
+    assert len(entities) >= 1
+    assert CodeProperty.HAS_SWITCH in entities[0]._tags
+
+
+def test_php_entity_has_exception(tmp_path):
+    src = """function foo($x) {
+    try {
+        return $x;
+    } catch (Exception $e) {
+        return null;
+    }
+}"""
+    entities = _get_entities(tmp_path, src)
+    assert len(entities) >= 1
+    assert CodeProperty.HAS_EXCEPTION in entities[0]._tags
+
+
+def test_php_entity_has_import(tmp_path):
+    src = """use App\\Models\\User;
+function foo() {
+    return new User();
+}"""
+    entities = _get_entities(tmp_path, src)
+    func_entities = [e for e in entities if e.node.type == "function_definition"]
+    # The import tag is checked at the walk level, so it might be on the function
+    # if the use statement is walked as part of the file
+    assert len(func_entities) >= 1
+
+
+def test_php_entity_has_lambda_arrow(tmp_path):
+    src = """function foo() {
+    $fn = fn($x) => $x * 2;
+    return $fn(5);
+}"""
+    entities = _get_entities(tmp_path, src)
+    assert len(entities) >= 1
+    assert CodeProperty.HAS_LAMBDA in entities[0]._tags
+
+
+def test_php_entity_has_lambda_anonymous(tmp_path):
+    """anonymous_function_creation_expression check in adapter.
+    tree-sitter-php uses 'anonymous_function' node type, so this won't
+    currently trigger HAS_LAMBDA. Verify it doesn't crash."""
+    src = """function foo() {
+    $fn = function($x) { return $x * 2; };
+    return $fn(5);
+}"""
+    entities = _get_entities(tmp_path, src)
+    assert len(entities) >= 1
+    # The adapter checks for 'anonymous_function_creation_expression' but
+    # tree-sitter uses 'anonymous_function', so this tag won't be set.
+    # Arrow functions (fn =>) do work correctly.
+    assert CodeProperty.HAS_LAMBDA not in entities[0]._tags
+
+
+def test_php_entity_has_arithmetic(tmp_path):
+    src = """function foo($x) {
+    return $x + 1;
+}"""
+    entities = _get_entities(tmp_path, src)
+    assert len(entities) >= 1
+    assert CodeProperty.HAS_ARITHMETIC in entities[0]._tags
+
+
+def test_php_entity_has_ternary(tmp_path):
+    src = """function foo($x) {
+    return $x > 0 ? "yes" : "no";
+}"""
+    entities = _get_entities(tmp_path, src)
+    assert len(entities) >= 1
+    assert CodeProperty.HAS_TERNARY in entities[0]._tags
+
+
+def test_php_entity_has_parent(tmp_path):
+    src = """class Child extends Parent {
+    public function doStuff() {
+        return 1;
+    }
+}"""
+    entities = _get_entities(tmp_path, src)
+    class_entities = [e for e in entities if e.node.type == "class_declaration"]
+    assert len(class_entities) >= 1
+    assert CodeProperty.HAS_PARENT in class_entities[0]._tags
+
+
+def test_php_entity_has_if_else(tmp_path):
+    src = """function foo($x) {
+    if ($x > 0) {
+        return "positive";
+    } else {
+        return "non-positive";
+    }
+}"""
+    entities = _get_entities(tmp_path, src)
+    assert len(entities) >= 1
+    assert CodeProperty.HAS_IF_ELSE in entities[0]._tags
+
+
+def test_php_entity_complexity(tmp_path):
+    src = """function foo($x, $y) {
+    if ($x > 0) {
+        if ($y > 0) {
+            return "both positive";
+        } else {
+            return "x positive";
+        }
+    }
+    for ($i = 0; $i < $x; $i++) {
+        echo $i;
+    }
+    return $x && $y ? "truthy" : "falsy";
+}"""
+    entities = _get_entities(tmp_path, src)
+    func_entities = [e for e in entities if e.node.type == "function_definition"]
+    assert len(func_entities) >= 1
+    # Should have complexity > 1 (base 1 + if + if + else + for + && + ternary)
+    assert func_entities[0].complexity >= 5
+
+
+def test_php_entity_no_body_stub(tmp_path):
+    """Test stub for entity without a body (signature only won't parse, but edge case)."""
+    src = """function simple() { return 1; }"""
+    entities = _get_entities(tmp_path, src)
+    assert len(entities) >= 1
+    assert entities[0].stub.endswith("}")
+
+
+def test_php_entity_method_without_parent_class(tmp_path):
+    """Test _find_parent_class returning None for a standalone function."""
+    src = """function standalone() {
+    return 42;
+}"""
+    entities = _get_entities(tmp_path, src)
+    assert len(entities) >= 1
+    # _find_parent_class should return None for a function_definition
+    result = entities[0]._find_parent_class()
+    assert result is None

--- a/tests/bug_gen/procedural/php/test_php_base.py
+++ b/tests/bug_gen/procedural/php/test_php_base.py
@@ -1,0 +1,33 @@
+from swesmith.bug_gen.procedural.php.base import php_parse
+
+
+def test_php_parse_without_tag():
+    """Code without <?php tag should have it prepended."""
+    src = "function foo() { return 1; }"
+    tree, offset = php_parse(src)
+    assert offset > 0
+    assert tree.root_node is not None
+
+
+def test_php_parse_with_tag():
+    """Code already starting with <?php should not be re-wrapped."""
+    src = "<?php\nfunction foo() { return 1; }"
+    tree, offset = php_parse(src)
+    assert offset == 0
+    assert tree.root_node is not None
+
+
+def test_php_parse_with_short_tag():
+    """Code starting with <? (short open tag) should not be re-wrapped."""
+    src = "<?\nfunction foo() { return 1; }"
+    tree, offset = php_parse(src)
+    assert offset == 0
+    assert tree.root_node is not None
+
+
+def test_php_parse_with_whitespace_before_tag():
+    """Code with leading whitespace before <?php should not be re-wrapped."""
+    src = "  <?php\nfunction foo() { return 1; }"
+    tree, offset = php_parse(src)
+    assert offset == 0
+    assert tree.root_node is not None

--- a/tests/bug_gen/procedural/php/test_php_base.py
+++ b/tests/bug_gen/procedural/php/test_php_base.py
@@ -1,33 +1,18 @@
 from swesmith.bug_gen.procedural.php.base import php_parse
 
 
-def test_php_parse_without_tag():
-    """Code without <?php tag should have it prepended."""
+def test_php_parse_plain_code():
+    """Plain PHP code should parse without needing a <?php tag."""
     src = "function foo() { return 1; }"
     tree, offset = php_parse(src)
-    assert offset > 0
-    assert tree.root_node is not None
-
-
-def test_php_parse_with_tag():
-    """Code already starting with <?php should not be re-wrapped."""
-    src = "<?php\nfunction foo() { return 1; }"
-    tree, offset = php_parse(src)
     assert offset == 0
     assert tree.root_node is not None
+    assert not tree.root_node.has_error
 
 
-def test_php_parse_with_short_tag():
-    """Code starting with <? (short open tag) should not be re-wrapped."""
-    src = "<?\nfunction foo() { return 1; }"
-    tree, offset = php_parse(src)
-    assert offset == 0
-    assert tree.root_node is not None
-
-
-def test_php_parse_with_whitespace_before_tag():
-    """Code with leading whitespace before <?php should not be re-wrapped."""
-    src = "  <?php\nfunction foo() { return 1; }"
-    tree, offset = php_parse(src)
-    assert offset == 0
-    assert tree.root_node is not None
+def test_php_parse_produces_function_node():
+    """Parser should produce a function_definition node."""
+    src = "function foo() { return 1; }"
+    tree, _ = php_parse(src)
+    children = [c.type for c in tree.root_node.children]
+    assert "function_definition" in children

--- a/tests/bug_gen/procedural/php/test_php_control_flow.py
+++ b/tests/bug_gen/procedural/php/test_php_control_flow.py
@@ -1,0 +1,74 @@
+import pytest
+from swesmith.bug_gen.adapters.php import get_entities_from_file_php
+from swesmith.bug_gen.procedural.php.control_flow import (
+    ControlIfElseInvertModifier,
+    ControlShuffleLinesModifier,
+)
+
+PHP_PREFIX = "<?php\n"
+
+
+def _get_entity(tmp_path, src):
+    test_file = tmp_path / "test.php"
+    test_file.write_text(PHP_PREFIX + src, encoding="utf-8")
+    entities = []
+    get_entities_from_file_php(entities, str(test_file))
+    assert len(entities) >= 1
+    return entities[0]
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        """function foo($x) {
+    if ($x > 0) {
+        return "positive";
+    } else {
+        return "non-positive";
+    }
+}""",
+        """function bar($a, $b) {
+    if ($a === $b) {
+        $result = true;
+    } else {
+        $result = false;
+    }
+    return $result;
+}""",
+    ],
+)
+def test_control_if_else_invert_modifier(tmp_path, src):
+    entity = _get_entity(tmp_path, src)
+    modifier = ControlIfElseInvertModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+
+    assert result is not None
+    assert result.rewrite != src
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        """function foo($x) {
+    $a = 1;
+    $b = 2;
+    $c = 3;
+    for ($i = 0; $i < $x; $i++) {
+        echo $i;
+    }
+    return $a + $b + $c;
+}""",
+    ],
+)
+def test_control_shuffle_lines_modifier(tmp_path, src):
+    entity = _get_entity(tmp_path, src)
+    modifier = ControlShuffleLinesModifier(likelihood=1.0, seed=42)
+
+    found_different = False
+    for _ in range(20):
+        result = modifier.modify(entity)
+        if result and result.rewrite != src:
+            found_different = True
+            break
+
+    assert found_different, "Expected shuffled output to differ from input"

--- a/tests/bug_gen/procedural/php/test_php_control_flow.py
+++ b/tests/bug_gen/procedural/php/test_php_control_flow.py
@@ -72,3 +72,57 @@ def test_control_shuffle_lines_modifier(tmp_path, src):
             break
 
     assert found_different, "Expected shuffled output to differ from input"
+
+
+def test_control_if_else_invert_no_else(tmp_path):
+    """If-only (no else) should return None."""
+    src = """function foo($x) {
+    if ($x > 0) {
+        return "positive";
+    }
+    return "other";
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = ControlIfElseInvertModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_control_if_else_invert_likelihood_zero(tmp_path):
+    """All retries fail when likelihood=0."""
+    src = """function foo($x) {
+    if ($x > 0) {
+        return "positive";
+    } else {
+        return "non-positive";
+    }
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = ControlIfElseInvertModifier(likelihood=0.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_control_shuffle_lines_no_function_body(tmp_path):
+    """Code without a proper function body should return None."""
+    src = """function foo($x) {
+    return $x;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = ControlShuffleLinesModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    # Only one statement, can't shuffle
+    assert result is None
+
+
+def test_control_shuffle_lines_likelihood_zero(tmp_path):
+    src = """function foo($x) {
+    $a = 1;
+    $b = 2;
+    $c = 3;
+    return $a + $b + $c;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = ControlShuffleLinesModifier(likelihood=0.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None

--- a/tests/bug_gen/procedural/php/test_php_control_flow.py
+++ b/tests/bug_gen/procedural/php/test_php_control_flow.py
@@ -18,16 +18,21 @@ def _get_entity(tmp_path, src):
 
 
 @pytest.mark.parametrize(
-    "src",
+    "src,orig_if_body,orig_else_body",
     [
-        """function foo($x) {
+        (
+            """function foo($x) {
     if ($x > 0) {
         return "positive";
     } else {
         return "non-positive";
     }
 }""",
-        """function bar($a, $b) {
+            'return "positive";',
+            'return "non-positive";',
+        ),
+        (
+            """function bar($a, $b) {
     if ($a === $b) {
         $result = true;
     } else {
@@ -35,15 +40,25 @@ def _get_entity(tmp_path, src):
     }
     return $result;
 }""",
+            "$result = true;",
+            "$result = false;",
+        ),
     ],
 )
-def test_control_if_else_invert_modifier(tmp_path, src):
+def test_control_if_else_invert_modifier(tmp_path, src, orig_if_body, orig_else_body):
     entity = _get_entity(tmp_path, src)
     modifier = ControlIfElseInvertModifier(likelihood=1.0, seed=42)
     result = modifier.modify(entity)
 
     assert result is not None
     assert result.rewrite != src
+    rewrite = result.rewrite
+    if_idx = rewrite.index("if")
+    else_idx = rewrite.index("else", if_idx)
+    if_block = rewrite[if_idx:else_idx]
+    else_block = rewrite[else_idx:]
+    assert orig_else_body in if_block
+    assert orig_if_body in else_block
 
 
 @pytest.mark.parametrize(
@@ -63,15 +78,38 @@ def test_control_if_else_invert_modifier(tmp_path, src):
 def test_control_shuffle_lines_modifier(tmp_path, src):
     entity = _get_entity(tmp_path, src)
     modifier = ControlShuffleLinesModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
 
-    found_different = False
-    for _ in range(20):
-        result = modifier.modify(entity)
-        if result and result.rewrite != src:
-            found_different = True
-            break
+    assert result is not None
+    assert result.rewrite != src
+    for stmt in ["$a = 1;", "$b = 2;", "$c = 3;"]:
+        assert stmt in result.rewrite
 
-    assert found_different, "Expected shuffled output to differ from input"
+
+def test_control_shuffle_lines_method(tmp_path):
+    """Shuffle lines within a class method."""
+    src = """class Calc {
+    public function compute($x) {
+        $a = 1;
+        $b = 2;
+        $c = 3;
+        return $a + $b + $c;
+    }
+}"""
+    test_file = tmp_path / "test.php"
+    test_file.write_text(PHP_PREFIX + src, encoding="utf-8")
+    entities = []
+    get_entities_from_file_php(entities, str(test_file))
+    method_entities = [e for e in entities if e.node.type == "method_declaration"]
+    assert len(method_entities) >= 1
+
+    modifier = ControlShuffleLinesModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(method_entities[0])
+
+    assert result is not None
+    assert result.rewrite != method_entities[0].src_code
+    for stmt in ["$a = 1;", "$b = 2;", "$c = 3;"]:
+        assert stmt in result.rewrite
 
 
 def test_control_if_else_invert_no_else(tmp_path):

--- a/tests/bug_gen/procedural/php/test_php_operations.py
+++ b/tests/bug_gen/procedural/php/test_php_operations.py
@@ -228,23 +228,45 @@ def test_ternary_operator_swap_modifier(tmp_path, src):
 
 
 @pytest.mark.parametrize(
-    "src",
+    "src,expected_call",
     [
-        """function foo() {
+        (
+            """function foo() {
     return add(1, 2);
 }""",
-        """function bar() {
+            "add(2, 1)",
+        ),
+        (
+            """function bar() {
     return compute($a, $b, $c);
 }""",
+            None,
+        ),
+        (
+            """function baz($obj) {
+    return $obj->method(1, 2);
+}""",
+            "method(2, 1)",
+        ),
+        (
+            """function qux() {
+    return MyClass::create($x, $y);
+}""",
+            "create($y, $x)",
+        ),
     ],
 )
-def test_function_argument_swap_modifier(tmp_path, src):
+def test_function_argument_swap_modifier(tmp_path, src, expected_call):
     entity = _get_entity(tmp_path, src)
     modifier = FunctionArgumentSwapModifier(likelihood=1.0, seed=42)
     result = modifier.modify(entity)
 
     assert result is not None
     assert result.rewrite != src
+    if expected_call:
+        assert expected_call in result.rewrite
+    else:
+        assert "compute(" in result.rewrite
 
 
 def test_safe_decode_valid():

--- a/tests/bug_gen/procedural/php/test_php_operations.py
+++ b/tests/bug_gen/procedural/php/test_php_operations.py
@@ -470,7 +470,9 @@ def test_operation_change_exponentiation(tmp_path):
     found = False
     for _ in range(20):
         result = modifier.modify(entity)
-        if result and any(op in result.rewrite for op in ["$a * $b", "$a / $b", "$a % $b"]):
+        if result and any(
+            op in result.rewrite for op in ["$a * $b", "$a / $b", "$a % $b"]
+        ):
             found = True
             break
     assert found, "Expected ** to be swapped with *, /, or %"

--- a/tests/bug_gen/procedural/php/test_php_operations.py
+++ b/tests/bug_gen/procedural/php/test_php_operations.py
@@ -570,7 +570,7 @@ def test_change_constants_float(tmp_path):
 
 
 def test_change_constants_hex(tmp_path):
-    """Test that hex literals are modified and stay in hex format."""
+    """Test that hex literals are modified."""
     src = """function foo() {
     return 0xFF + $x;
 }"""
@@ -578,21 +578,19 @@ def test_change_constants_hex(tmp_path):
     modifier = OperationChangeConstantsModifier(likelihood=1.0, seed=42)
     result = modifier.modify(entity)
     assert result is not None
-    assert "0x" in result.rewrite
     assert "0xFF" not in result.rewrite
 
 
-def test_change_constants_octal_skipped(tmp_path):
-    """Test that legacy octal literals are handled correctly."""
+def test_change_constants_octal(tmp_path):
+    """Test that octal literals are handled correctly."""
     src = """function foo() {
     return 077 + $x;
 }"""
     entity = _get_entity(tmp_path, src)
     modifier = OperationChangeConstantsModifier(likelihood=1.0, seed=42)
     result = modifier.modify(entity)
-    if result is not None:
-        # Should stay in octal format (start with 0)
-        assert "077" not in result.rewrite
+    assert result is not None
+    assert "077" not in result.rewrite
 
 
 def test_break_chains_nested_no_corruption(tmp_path):
@@ -603,7 +601,6 @@ def test_break_chains_nested_no_corruption(tmp_path):
     entity = _get_entity(tmp_path, src)
     modifier = OperationBreakChainsModifier(likelihood=1.0, seed=42)
     result = modifier.modify(entity)
-    if result is not None:
-        # The result should be valid PHP (no garbled output)
-        assert "function foo" in result.rewrite
-        assert "return" in result.rewrite
+    assert result is not None
+    assert "function foo" in result.rewrite
+    assert "return" in result.rewrite

--- a/tests/bug_gen/procedural/php/test_php_operations.py
+++ b/tests/bug_gen/procedural/php/test_php_operations.py
@@ -57,15 +57,12 @@ def _get_entity(tmp_path, src):
 def test_operation_change_modifier(tmp_path, src, expected_variants):
     entity = _get_entity(tmp_path, src)
     modifier = OperationChangeModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
 
-    found_variant = False
-    for _ in range(20):
-        result = modifier.modify(entity)
-        if result and any(v in result.rewrite for v in expected_variants):
-            found_variant = True
-            break
-
-    assert found_variant, f"Expected one of {expected_variants} in output"
+    assert result is not None
+    assert any(v in result.rewrite for v in expected_variants), (
+        f"Expected one of {expected_variants} in output, got: {result.rewrite}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -75,19 +72,73 @@ def test_operation_change_modifier(tmp_path, src, expected_variants):
             """function foo($a, $b) {
     return $a === $b;
 }""",
-            "!==",
+            "return $a !== $b;",
         ),
         (
-            """function bar($x, $y) {
+            """function foo($a, $b) {
+    return $a !== $b;
+}""",
+            "return $a === $b;",
+        ),
+        (
+            """function foo($a, $b) {
+    return $a == $b;
+}""",
+            "return $a != $b;",
+        ),
+        (
+            """function foo($a, $b) {
+    return $a != $b;
+}""",
+            "return $a == $b;",
+        ),
+        (
+            """function foo($x, $y) {
     return $x < $y;
 }""",
-            ">=",
+            "return $x >= $y;",
         ),
         (
-            """function baz($a, $b) {
+            """function foo($x, $y) {
+    return $x >= $y;
+}""",
+            "return $x < $y;",
+        ),
+        (
+            """function foo($x, $y) {
+    return $x > $y;
+}""",
+            "return $x <= $y;",
+        ),
+        (
+            """function foo($x, $y) {
+    return $x <= $y;
+}""",
+            "return $x > $y;",
+        ),
+        (
+            """function foo($a, $b) {
     return $a && $b;
 }""",
-            "||",
+            "return $a || $b;",
+        ),
+        (
+            """function foo($a, $b) {
+    return $a || $b;
+}""",
+            "return $a && $b;",
+        ),
+        (
+            """function foo($a, $b) {
+    return $a and $b;
+}""",
+            "return $a or $b;",
+        ),
+        (
+            """function foo($a, $b) {
+    return $a or $b;
+}""",
+            "return $a and $b;",
         ),
     ],
 )
@@ -101,69 +152,86 @@ def test_operation_flip_operator_modifier(tmp_path, src, expected_substring):
 
 
 @pytest.mark.parametrize(
-    "src",
+    "src,expected_substring",
     [
-        """function foo($a, $b) {
+        (
+            """function foo($a, $b) {
     return $a + $b;
 }""",
-        """function bar($x, $y) {
+            "return $b + $a;",
+        ),
+        (
+            """function bar($x, $y) {
     return $x - $y;
 }""",
+            "return $y - $x;",
+        ),
     ],
 )
-def test_operation_swap_operands_modifier(tmp_path, src):
+def test_operation_swap_operands_modifier(tmp_path, src, expected_substring):
     entity = _get_entity(tmp_path, src)
     modifier = OperationSwapOperandsModifier(likelihood=1.0, seed=42)
     result = modifier.modify(entity)
 
     assert result is not None
-    assert result.rewrite != src
+    assert expected_substring in result.rewrite
 
 
 @pytest.mark.parametrize(
-    "src,expected_variants",
+    "src,original,expected_variants",
     [
         (
             """function foo() {
     return 2 + $x;
 }""",
-            ["1", "3", "0", "4"],
+            "return 2 + $x;",
+            ["return 1 + $x;", "return 3 + $x;", "return 0 + $x;", "return 4 + $x;"],
         ),
         (
             """function bar() {
     return $y - 5;
 }""",
-            ["4", "6", "3", "7"],
+            "return $y - 5;",
+            ["return $y - 4;", "return $y - 6;", "return $y - 3;", "return $y - 7;"],
         ),
     ],
 )
-def test_operation_change_constants_modifier(tmp_path, src, expected_variants):
+def test_operation_change_constants_modifier(tmp_path, src, original, expected_variants):
     entity = _get_entity(tmp_path, src)
     modifier = OperationChangeConstantsModifier(likelihood=1.0, seed=42)
     result = modifier.modify(entity)
 
     assert result is not None
-    assert any(v in result.rewrite for v in expected_variants)
+    assert original not in result.rewrite
+    assert any(v in result.rewrite for v in expected_variants), (
+        f"Expected one of {expected_variants} in output, got: {result.rewrite}"
+    )
 
 
 @pytest.mark.parametrize(
-    "src",
+    "src,dropped_operand",
     [
-        """function foo($a, $b, $c) {
+        (
+            """function foo($a, $b, $c) {
     return $a + $b + $c;
 }""",
-        """function bar($x, $y, $z) {
+            "$a",
+        ),
+        (
+            """function bar($x, $y, $z) {
     return $x * $y * $z;
 }""",
+            "$x",
+        ),
     ],
 )
-def test_operation_break_chains_modifier(tmp_path, src):
+def test_operation_break_chains_modifier(tmp_path, src, dropped_operand):
     entity = _get_entity(tmp_path, src)
     modifier = OperationBreakChainsModifier(likelihood=1.0, seed=42)
     result = modifier.modify(entity)
 
     assert result is not None
-    assert result.rewrite != src
+    assert dropped_operand + " " not in result.rewrite.split("return")[1]
 
 
 @pytest.mark.parametrize(
@@ -174,21 +242,21 @@ def test_operation_break_chains_modifier(tmp_path, src):
     $x += 5;
     return $x;
 }""",
-            "-=",
+            "$x -= 5;",
         ),
         (
             """function bar($y) {
     $y *= 2;
     return $y;
 }""",
-            "/=",
+            "$y /= 2;",
         ),
         (
             """function baz($n) {
     $n++;
     return $n;
 }""",
-            "--",
+            "$n--;",
         ),
     ],
 )
@@ -202,23 +270,29 @@ def test_augmented_assignment_swap_modifier(tmp_path, src, expected_substring):
 
 
 @pytest.mark.parametrize(
-    "src",
+    "src,expected_substring",
     [
-        """function foo($condition) {
+        (
+            """function foo($condition) {
     return $condition ? "yes" : "no";
 }""",
-        """function bar($x) {
+            'return $condition ? "no" : "yes";',
+        ),
+        (
+            """function bar($x) {
     return $x > 0 ? 1 : -1;
 }""",
+            "return $x > 0 ? -1 : 1;",
+        ),
     ],
 )
-def test_ternary_operator_swap_modifier(tmp_path, src):
+def test_ternary_operator_swap_modifier(tmp_path, src, expected_substring):
     entity = _get_entity(tmp_path, src)
     modifier = TernaryOperatorSwapModifier(likelihood=1.0, seed=42)
     result = modifier.modify(entity)
 
     assert result is not None
-    assert result.rewrite != src
+    assert expected_substring in result.rewrite
 
 
 @pytest.mark.parametrize(
@@ -368,8 +442,8 @@ def test_operation_break_chains_right_chain(tmp_path):
     entity = _get_entity(tmp_path, src)
     modifier = OperationBreakChainsModifier(likelihood=1.0, seed=42)
     result = modifier.modify(entity)
-    if result is not None:
-        assert result.rewrite != entity.src_code
+    # Parenthesized expression isn't detected as a chain, so no modification
+    assert result is None
 
 
 def test_operation_break_chains_likelihood_zero(tmp_path):
@@ -409,15 +483,11 @@ def test_ternary_swap_negate_condition(tmp_path):
     return $x > 0 ? "yes" : "no";
 }"""
     entity = _get_entity(tmp_path, src)
-    for seed in range(50):
-        modifier = TernaryOperatorSwapModifier(likelihood=1.0, seed=seed)
-        result = modifier.modify(entity)
-        if result and "!(" in result.rewrite:
-            assert "!(" in result.rewrite
-            return
-    modifier = TernaryOperatorSwapModifier(likelihood=1.0, seed=42)
+    # seed=0 produces negation
+    modifier = TernaryOperatorSwapModifier(likelihood=1.0, seed=0)
     result = modifier.modify(entity)
     assert result is not None
+    assert '!($x > 0) ? "yes" : "no"' in result.rewrite
 
 
 def test_ternary_swap_no_ternary(tmp_path):
@@ -426,6 +496,16 @@ def test_ternary_swap_no_ternary(tmp_path):
 }"""
     entity = _get_entity(tmp_path, src)
     modifier = TernaryOperatorSwapModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_ternary_swap_likelihood_zero(tmp_path):
+    src = """function foo($x) {
+    return $x > 0 ? "yes" : "no";
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = TernaryOperatorSwapModifier(likelihood=0.0, seed=42)
     result = modifier.modify(entity)
     assert result is None
 
@@ -467,15 +547,11 @@ def test_operation_change_exponentiation(tmp_path):
 }"""
     entity = _get_entity(tmp_path, src)
     modifier = OperationChangeModifier(likelihood=1.0, seed=42)
-    found = False
-    for _ in range(20):
-        result = modifier.modify(entity)
-        if result and any(
-            op in result.rewrite for op in ["$a * $b", "$a / $b", "$a % $b"]
-        ):
-            found = True
-            break
-    assert found, "Expected ** to be swapped with *, /, or %"
+    result = modifier.modify(entity)
+    assert result is not None
+    assert any(
+        op in result.rewrite for op in ["return $a * $b;", "return $a / $b;", "return $a % $b;"]
+    ), f"Expected ** to be swapped, got: {result.rewrite}"
 
 
 def test_change_constants_float(tmp_path):

--- a/tests/bug_gen/procedural/php/test_php_operations.py
+++ b/tests/bug_gen/procedural/php/test_php_operations.py
@@ -1,0 +1,246 @@
+import pytest
+from swesmith.bug_gen.adapters.php import get_entities_from_file_php
+from swesmith.bug_gen.procedural.php.operations import (
+    OperationChangeModifier,
+    OperationFlipOperatorModifier,
+    OperationSwapOperandsModifier,
+    OperationChangeConstantsModifier,
+    OperationBreakChainsModifier,
+    AugmentedAssignmentSwapModifier,
+    TernaryOperatorSwapModifier,
+    FunctionArgumentSwapModifier,
+)
+
+PHP_PREFIX = "<?php\n"
+
+
+def _get_entity(tmp_path, src):
+    test_file = tmp_path / "test.php"
+    test_file.write_text(PHP_PREFIX + src, encoding="utf-8")
+    entities = []
+    get_entities_from_file_php(entities, str(test_file))
+    assert len(entities) >= 1
+    return entities[0]
+
+
+@pytest.mark.parametrize(
+    "src,expected_variants",
+    [
+        (
+            """function foo($a, $b) {
+    return $a + $b;
+}""",
+            ["return $a - $b;"],
+        ),
+        (
+            """function bar($x, $y) {
+    return $x * $y;
+}""",
+            ["return $x / $y;", "return $x % $y;"],
+        ),
+        (
+            """function baz($a, $b) {
+    return $a & $b;
+}""",
+            ["return $a | $b;", "return $a ^ $b;"],
+        ),
+        # PHP string concatenation
+        (
+            """function concat($a, $b) {
+    return $a . $b;
+}""",
+            ["return $a + $b;"],
+        ),
+    ],
+)
+def test_operation_change_modifier(tmp_path, src, expected_variants):
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationChangeModifier(likelihood=1.0, seed=42)
+
+    found_variant = False
+    for _ in range(20):
+        result = modifier.modify(entity)
+        if result and any(v in result.rewrite for v in expected_variants):
+            found_variant = True
+            break
+
+    assert found_variant, f"Expected one of {expected_variants} in output"
+
+
+@pytest.mark.parametrize(
+    "src,expected_substring",
+    [
+        (
+            """function foo($a, $b) {
+    return $a === $b;
+}""",
+            "!==",
+        ),
+        (
+            """function bar($x, $y) {
+    return $x < $y;
+}""",
+            ">=",
+        ),
+        (
+            """function baz($a, $b) {
+    return $a && $b;
+}""",
+            "||",
+        ),
+        (
+            """function qux($a, $b) {
+    return $a + $b;
+}""",
+            "-",
+        ),
+    ],
+)
+def test_operation_flip_operator_modifier(tmp_path, src, expected_substring):
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationFlipOperatorModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+
+    assert result is not None
+    assert expected_substring in result.rewrite
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        """function foo($a, $b) {
+    return $a + $b;
+}""",
+        """function bar($x, $y) {
+    return $x - $y;
+}""",
+    ],
+)
+def test_operation_swap_operands_modifier(tmp_path, src):
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationSwapOperandsModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+
+    assert result is not None
+    assert result.rewrite != src
+
+
+@pytest.mark.parametrize(
+    "src,expected_variants",
+    [
+        (
+            """function foo() {
+    return 2 + $x;
+}""",
+            ["1", "3", "0", "4"],
+        ),
+        (
+            """function bar() {
+    return $y - 5;
+}""",
+            ["4", "6", "3", "7"],
+        ),
+    ],
+)
+def test_operation_change_constants_modifier(tmp_path, src, expected_variants):
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationChangeConstantsModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+
+    assert result is not None
+    assert any(v in result.rewrite for v in expected_variants)
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        """function foo($a, $b, $c) {
+    return $a + $b + $c;
+}""",
+        """function bar($x, $y, $z) {
+    return $x * $y * $z;
+}""",
+    ],
+)
+def test_operation_break_chains_modifier(tmp_path, src):
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationBreakChainsModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+
+    assert result is not None
+    assert result.rewrite != src
+
+
+@pytest.mark.parametrize(
+    "src,expected_substring",
+    [
+        (
+            """function foo($x) {
+    $x += 5;
+    return $x;
+}""",
+            "-=",
+        ),
+        (
+            """function bar($y) {
+    $y *= 2;
+    return $y;
+}""",
+            "/=",
+        ),
+        (
+            """function baz($n) {
+    $n++;
+    return $n;
+}""",
+            "--",
+        ),
+    ],
+)
+def test_augmented_assignment_swap_modifier(tmp_path, src, expected_substring):
+    entity = _get_entity(tmp_path, src)
+    modifier = AugmentedAssignmentSwapModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+
+    assert result is not None
+    assert expected_substring in result.rewrite
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        """function foo($condition) {
+    return $condition ? "yes" : "no";
+}""",
+        """function bar($x) {
+    return $x > 0 ? 1 : -1;
+}""",
+    ],
+)
+def test_ternary_operator_swap_modifier(tmp_path, src):
+    entity = _get_entity(tmp_path, src)
+    modifier = TernaryOperatorSwapModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+
+    assert result is not None
+    assert result.rewrite != src
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        """function foo() {
+    return add(1, 2);
+}""",
+        """function bar() {
+    return compute($a, $b, $c);
+}""",
+    ],
+)
+def test_function_argument_swap_modifier(tmp_path, src):
+    entity = _get_entity(tmp_path, src)
+    modifier = FunctionArgumentSwapModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+
+    assert result is not None
+    assert result.rewrite != src

--- a/tests/bug_gen/procedural/php/test_php_operations.py
+++ b/tests/bug_gen/procedural/php/test_php_operations.py
@@ -89,12 +89,6 @@ def test_operation_change_modifier(tmp_path, src, expected_variants):
 }""",
             "||",
         ),
-        (
-            """function qux($a, $b) {
-    return $a + $b;
-}""",
-            "-",
-        ),
     ],
 )
 def test_operation_flip_operator_modifier(tmp_path, src, expected_substring):
@@ -323,8 +317,8 @@ def test_operation_swap_operands_no_changes_likelihood_zero(tmp_path):
     assert result is None
 
 
-def test_operation_swap_operands_comparison_flip(tmp_path):
-    """Test that comparison operators are flipped when operands are swapped."""
+def test_operation_swap_operands_comparison_no_flip(tmp_path):
+    """Test that comparison operators are NOT flipped when operands are swapped (to actually change semantics)."""
     src = """function foo($a, $b) {
     return $a < $b;
 }"""
@@ -332,6 +326,8 @@ def test_operation_swap_operands_comparison_flip(tmp_path):
     modifier = OperationSwapOperandsModifier(likelihood=1.0, seed=42)
     result = modifier.modify(entity)
     assert result is not None
+    # Operator should stay as "<" (not flipped to ">"), so "$b < $a" changes behavior
+    assert "$b < $a" in result.rewrite
 
 
 def test_operation_change_constants_no_integers(tmp_path):
@@ -462,3 +458,71 @@ def test_function_argument_swap_likelihood_zero(tmp_path):
     modifier = FunctionArgumentSwapModifier(likelihood=0.0, seed=42)
     result = modifier.modify(entity)
     assert result is None
+
+
+def test_operation_change_exponentiation(tmp_path):
+    """Test that ** operator can be swapped with *, /, %."""
+    src = """function foo($a, $b) {
+    return $a ** $b;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationChangeModifier(likelihood=1.0, seed=42)
+    found = False
+    for _ in range(20):
+        result = modifier.modify(entity)
+        if result and any(op in result.rewrite for op in ["$a * $b", "$a / $b", "$a % $b"]):
+            found = True
+            break
+    assert found, "Expected ** to be swapped with *, /, or %"
+
+
+def test_change_constants_float(tmp_path):
+    """Test that float literals are modified."""
+    src = """function foo() {
+    return 3.14 + $x;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationChangeConstantsModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is not None
+    assert "3.14" not in result.rewrite
+
+
+def test_change_constants_hex(tmp_path):
+    """Test that hex literals are modified and stay in hex format."""
+    src = """function foo() {
+    return 0xFF + $x;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationChangeConstantsModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is not None
+    assert "0x" in result.rewrite
+    assert "0xFF" not in result.rewrite
+
+
+def test_change_constants_octal_skipped(tmp_path):
+    """Test that legacy octal literals are handled correctly."""
+    src = """function foo() {
+    return 077 + $x;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationChangeConstantsModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    if result is not None:
+        # Should stay in octal format (start with 0)
+        assert "077" not in result.rewrite
+
+
+def test_break_chains_nested_no_corruption(tmp_path):
+    """Test that nested expressions don't get corrupted by overlapping changes."""
+    src = """function foo($a, $b, $c, $d, $extra) {
+    return foo($a + $b + $c + $d) + $extra;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationBreakChainsModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    if result is not None:
+        # The result should be valid PHP (no garbled output)
+        assert "function foo" in result.rewrite
+        assert "return" in result.rewrite

--- a/tests/bug_gen/procedural/php/test_php_operations.py
+++ b/tests/bug_gen/procedural/php/test_php_operations.py
@@ -196,7 +196,9 @@ def test_operation_swap_operands_modifier(tmp_path, src, expected_substring):
         ),
     ],
 )
-def test_operation_change_constants_modifier(tmp_path, src, original, expected_variants):
+def test_operation_change_constants_modifier(
+    tmp_path, src, original, expected_variants
+):
     entity = _get_entity(tmp_path, src)
     modifier = OperationChangeConstantsModifier(likelihood=1.0, seed=42)
     result = modifier.modify(entity)
@@ -550,7 +552,8 @@ def test_operation_change_exponentiation(tmp_path):
     result = modifier.modify(entity)
     assert result is not None
     assert any(
-        op in result.rewrite for op in ["return $a * $b;", "return $a / $b;", "return $a % $b;"]
+        op in result.rewrite
+        for op in ["return $a * $b;", "return $a / $b;", "return $a % $b;"]
     ), f"Expected ** to be swapped, got: {result.rewrite}"
 
 

--- a/tests/bug_gen/procedural/php/test_php_operations.py
+++ b/tests/bug_gen/procedural/php/test_php_operations.py
@@ -1,6 +1,7 @@
 import pytest
 from swesmith.bug_gen.adapters.php import get_entities_from_file_php
 from swesmith.bug_gen.procedural.php.operations import (
+    _safe_decode,
     OperationChangeModifier,
     OperationFlipOperatorModifier,
     OperationSwapOperandsModifier,
@@ -244,3 +245,198 @@ def test_function_argument_swap_modifier(tmp_path, src):
 
     assert result is not None
     assert result.rewrite != src
+
+
+def test_safe_decode_valid():
+    assert _safe_decode(b"hello") == "hello"
+
+
+def test_safe_decode_invalid_utf8():
+    result = _safe_decode(b"\xff\xfe", fallback="fallback")
+    assert result == "fallback"
+
+
+def test_safe_decode_invalid_utf8_default_fallback():
+    result = _safe_decode(b"\xff\xfe")
+    assert result == ""
+
+
+def test_operation_change_no_changes_likelihood_zero(tmp_path):
+    src = """function foo($a, $b) {
+    return $a + $b;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationChangeModifier(likelihood=0.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_operation_change_no_binary_ops(tmp_path):
+    src = """function foo($x) {
+    return $x;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationChangeModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_operation_flip_no_changes_likelihood_zero(tmp_path):
+    src = """function foo($a, $b) {
+    return $a === $b;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationFlipOperatorModifier(likelihood=0.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_operation_swap_operands_no_changes_likelihood_zero(tmp_path):
+    src = """function foo($a, $b) {
+    return $a + $b;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationSwapOperandsModifier(likelihood=0.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_operation_swap_operands_comparison_flip(tmp_path):
+    """Test that comparison operators are flipped when operands are swapped."""
+    src = """function foo($a, $b) {
+    return $a < $b;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationSwapOperandsModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is not None
+
+
+def test_operation_change_constants_no_integers(tmp_path):
+    src = """function foo($x) {
+    return $x;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationChangeConstantsModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_operation_change_constants_likelihood_zero(tmp_path):
+    src = """function foo() {
+    return 42;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationChangeConstantsModifier(likelihood=0.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_operation_break_chains_no_chains(tmp_path):
+    src = """function foo($a, $b) {
+    return $a + $b;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationBreakChainsModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_operation_break_chains_right_chain(tmp_path):
+    """Test breaking chains where the right side is a binary expression."""
+    src = """function foo($a, $b, $c) {
+    return $a + ($b + $c);
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationBreakChainsModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    if result is not None:
+        assert result.rewrite != entity.src_code
+
+
+def test_operation_break_chains_likelihood_zero(tmp_path):
+    src = """function foo($a, $b, $c) {
+    return $a + $b + $c;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = OperationBreakChainsModifier(likelihood=0.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_augmented_assignment_swap_no_assignments(tmp_path):
+    src = """function foo($x) {
+    return $x;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = AugmentedAssignmentSwapModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_augmented_assignment_swap_likelihood_zero(tmp_path):
+    src = """function foo($x) {
+    $x += 5;
+    return $x;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = AugmentedAssignmentSwapModifier(likelihood=0.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_ternary_swap_negate_condition(tmp_path):
+    """Test that the negate_condition path is exercised."""
+    src = """function foo($x) {
+    return $x > 0 ? "yes" : "no";
+}"""
+    entity = _get_entity(tmp_path, src)
+    for seed in range(50):
+        modifier = TernaryOperatorSwapModifier(likelihood=1.0, seed=seed)
+        result = modifier.modify(entity)
+        if result and "!(" in result.rewrite:
+            assert "!(" in result.rewrite
+            return
+    modifier = TernaryOperatorSwapModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is not None
+
+
+def test_ternary_swap_no_ternary(tmp_path):
+    src = """function foo($x) {
+    return $x;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = TernaryOperatorSwapModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_function_argument_swap_no_calls(tmp_path):
+    src = """function foo($x) {
+    return $x;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = FunctionArgumentSwapModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_function_argument_swap_single_arg(tmp_path):
+    src = """function foo() {
+    return strlen("hello");
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = FunctionArgumentSwapModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_function_argument_swap_likelihood_zero(tmp_path):
+    src = """function foo() {
+    return add(1, 2);
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = FunctionArgumentSwapModifier(likelihood=0.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None

--- a/tests/bug_gen/procedural/php/test_php_remove.py
+++ b/tests/bug_gen/procedural/php/test_php_remove.py
@@ -239,7 +239,7 @@ def test_remove_assignment_nested_no_corruption(tmp_path):
     result = modifier.modify(entity)
     assert result is not None
     # Should cleanly remove the whole statement, not corrupt 'echo' into 'o'
-    assert "echo" in result.rewrite or "$a = $b = 5" not in result.rewrite
+    assert "echo" in result.rewrite and "$a = $b = 5" not in result.rewrite
 
 
 def test_remove_assignment_reference(tmp_path):

--- a/tests/bug_gen/procedural/php/test_php_remove.py
+++ b/tests/bug_gen/procedural/php/test_php_remove.py
@@ -1,0 +1,135 @@
+import pytest
+from swesmith.bug_gen.adapters.php import get_entities_from_file_php
+from swesmith.bug_gen.procedural.php.remove import (
+    RemoveLoopModifier,
+    RemoveConditionalModifier,
+    RemoveAssignmentModifier,
+    RemoveTernaryModifier,
+)
+
+PHP_PREFIX = "<?php\n"
+
+
+def _get_entity(tmp_path, src):
+    test_file = tmp_path / "test.php"
+    test_file.write_text(PHP_PREFIX + src, encoding="utf-8")
+    entities = []
+    get_entities_from_file_php(entities, str(test_file))
+    assert len(entities) >= 1
+    return entities[0]
+
+
+@pytest.mark.parametrize(
+    "src,loop_keyword",
+    [
+        (
+            """function foo($arr) {
+    $sum = 0;
+    for ($i = 0; $i < count($arr); $i++) {
+        $sum += $arr[$i];
+    }
+    return $sum;
+}""",
+            "for",
+        ),
+        (
+            """function bar($items) {
+    $result = [];
+    foreach ($items as $item) {
+        $result[] = $item * 2;
+    }
+    return $result;
+}""",
+            "foreach",
+        ),
+        (
+            """function baz($n) {
+    $i = 0;
+    while ($i < $n) {
+        echo $i;
+        $i++;
+    }
+}""",
+            "while",
+        ),
+    ],
+)
+def test_remove_loop_modifier(tmp_path, src, loop_keyword):
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveLoopModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+
+    assert result is not None
+    assert result.rewrite != src
+    assert loop_keyword not in result.rewrite or len(result.rewrite) < len(src)
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        """function foo($x) {
+    if ($x > 0) {
+        return "positive";
+    }
+    return "non-positive";
+}""",
+        """function bar($a, $b) {
+    if ($a === $b) {
+        return true;
+    }
+    return false;
+}""",
+    ],
+)
+def test_remove_conditional_modifier(tmp_path, src):
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveConditionalModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+
+    assert result is not None
+    assert result.rewrite != src
+    assert len(result.rewrite) < len(src)
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        """function foo($x) {
+    $y = $x + 1;
+    return $y;
+}""",
+        """function bar($a) {
+    $a += 5;
+    return $a;
+}""",
+    ],
+)
+def test_remove_assignment_modifier(tmp_path, src):
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveAssignmentModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+
+    assert result is not None
+    assert result.rewrite != src
+    assert len(result.rewrite) < len(src)
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        """function foo($x) {
+    return $x > 0 ? "yes" : "no";
+}""",
+        """function bar($a, $b) {
+    return $a === $b ? 1 : 0;
+}""",
+    ],
+)
+def test_remove_ternary_modifier(tmp_path, src):
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveTernaryModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+
+    assert result is not None
+    assert result.rewrite != src
+    assert "?" not in result.rewrite

--- a/tests/bug_gen/procedural/php/test_php_remove.py
+++ b/tests/bug_gen/procedural/php/test_php_remove.py
@@ -133,3 +133,91 @@ def test_remove_ternary_modifier(tmp_path, src):
     assert result is not None
     assert result.rewrite != src
     assert "?" not in result.rewrite
+
+
+def test_remove_loop_no_loops(tmp_path):
+    src = """function foo($x) {
+    return $x;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveLoopModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_remove_loop_likelihood_zero(tmp_path):
+    src = """function foo($arr) {
+    $sum = 0;
+    for ($i = 0; $i < count($arr); $i++) {
+        $sum += $arr[$i];
+    }
+    return $sum;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveLoopModifier(likelihood=0.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_remove_conditional_no_conditionals(tmp_path):
+    src = """function foo($x) {
+    return $x;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveConditionalModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_remove_conditional_likelihood_zero(tmp_path):
+    src = """function foo($x) {
+    if ($x > 0) {
+        return "positive";
+    }
+    return "other";
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveConditionalModifier(likelihood=0.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_remove_assignment_no_assignments(tmp_path):
+    src = """function foo($x) {
+    return $x;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveAssignmentModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_remove_assignment_likelihood_zero(tmp_path):
+    src = """function foo($x) {
+    $y = $x + 1;
+    return $y;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveAssignmentModifier(likelihood=0.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_remove_ternary_no_ternary(tmp_path):
+    src = """function foo($x) {
+    return $x;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveTernaryModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None
+
+
+def test_remove_ternary_likelihood_zero(tmp_path):
+    src = """function foo($x) {
+    return $x > 0 ? "yes" : "no";
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveTernaryModifier(likelihood=0.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is None

--- a/tests/bug_gen/procedural/php/test_php_remove.py
+++ b/tests/bug_gen/procedural/php/test_php_remove.py
@@ -221,3 +221,59 @@ def test_remove_ternary_likelihood_zero(tmp_path):
     modifier = RemoveTernaryModifier(likelihood=0.0, seed=42)
     result = modifier.modify(entity)
     assert result is None
+
+
+def test_remove_assignment_nested_no_corruption(tmp_path):
+    """Test that nested assignments like $a = $b = 5 don't corrupt output."""
+    src = """function foo($x) {
+    $a = $b = 5;
+    echo $a + $b;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveAssignmentModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is not None
+    # Should cleanly remove the whole statement, not corrupt 'echo' into 'o'
+    assert "echo" in result.rewrite or "$a = $b = 5" not in result.rewrite
+
+
+def test_remove_assignment_reference(tmp_path):
+    """Test that reference assignments ($b = &$a) are removed."""
+    src = """function foo($a) {
+    $b = &$a;
+    return $b;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveAssignmentModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is not None
+    assert "&$a" not in result.rewrite
+
+
+def test_remove_ternary_nested_no_corruption(tmp_path):
+    """Test that nested ternaries don't lose trailing code."""
+    src = """function foo($a, $b, $c, $d, $e) {
+    return $a ? $b : $c ? $d : $e;
+}"""
+    entity = _get_entity(tmp_path, src)
+    modifier = RemoveTernaryModifier(likelihood=1.0, seed=42)
+    result = modifier.modify(entity)
+    assert result is not None
+    assert result.rewrite.rstrip().endswith("}")
+
+
+def test_remove_ternary_elvis_operator(tmp_path):
+    """Test that the elvis operator ($x ?: $default) is supported."""
+    src = """function foo($x, $default) {
+    return $x ?: $default;
+}"""
+    entity = _get_entity(tmp_path, src)
+    found = False
+    for seed in range(20):
+        modifier = RemoveTernaryModifier(likelihood=1.0, seed=seed)
+        result = modifier.modify(entity)
+        if result:
+            found = True
+            assert "?:" not in result.rewrite
+            break
+    assert found, "Elvis operator should be supported"

--- a/tests/bug_gen/procedural/php/test_php_remove.py
+++ b/tests/bug_gen/procedural/php/test_php_remove.py
@@ -61,7 +61,7 @@ def test_remove_loop_modifier(tmp_path, src, loop_keyword):
 
     assert result is not None
     assert result.rewrite != src
-    assert loop_keyword not in result.rewrite or len(result.rewrite) < len(src)
+    assert loop_keyword not in result.rewrite
 
 
 @pytest.mark.parametrize(
@@ -92,26 +92,31 @@ def test_remove_conditional_modifier(tmp_path, src):
 
 
 @pytest.mark.parametrize(
-    "src",
+    "src,removed_statement",
     [
-        """function foo($x) {
+        (
+            """function foo($x) {
     $y = $x + 1;
     return $y;
 }""",
-        """function bar($a) {
+            "$y = $x + 1;",
+        ),
+        (
+            """function bar($a) {
     $a += 5;
     return $a;
 }""",
+            "$a += 5;",
+        ),
     ],
 )
-def test_remove_assignment_modifier(tmp_path, src):
+def test_remove_assignment_modifier(tmp_path, src, removed_statement):
     entity = _get_entity(tmp_path, src)
     modifier = RemoveAssignmentModifier(likelihood=1.0, seed=42)
     result = modifier.modify(entity)
 
     assert result is not None
-    assert result.rewrite != src
-    assert len(result.rewrite) < len(src)
+    assert removed_statement not in result.rewrite
 
 
 @pytest.mark.parametrize(

--- a/tests/profiles/test_profiles_php.py
+++ b/tests/profiles/test_profiles_php.py
@@ -8,7 +8,6 @@ from swesmith.profiles.php import (
     Monolog6db20ca0,
     Guzzlefb92d95f,
     parse_log_phpunit_testdox,
-    parse_log_phpunit_verbose,
 )
 from swesmith.constants import ENV_NAME
 from swebench.harness.constants import TestStatus
@@ -49,41 +48,51 @@ def _make_profile_with_clone(tmp_path):
 
 def _make_profile_with_cache(cache):
     profile = make_dummy_php_profile()
-    profile._test_name_to_files_cache = cache
+    profile._fqcn_to_file_cache = cache
     return profile
 
 
-# --- Log parser tests ---
 
-
-def test_parse_log_phpunit_testdox_passed():
-    log = " ✔ Prepare\n ✔ Query\n ✔ Exec"
+def test_parse_log_phpunit_testdox_with_class_header():
+    log = (
+        "Connection (Doctrine\\DBAL\\Tests\\ConnectionTest)\n"
+        " ✔ Prepare\n"
+        " ✔ Query\n"
+        " ✘ Exec"
+    )
     result = parse_log_phpunit_testdox(log)
-    assert result["Prepare"] == TestStatus.PASSED.value
-    assert result["Query"] == TestStatus.PASSED.value
-    assert result["Exec"] == TestStatus.PASSED.value
+    assert result["Doctrine\\DBAL\\Tests\\ConnectionTest::Prepare"] == TestStatus.PASSED.value
+    assert result["Doctrine\\DBAL\\Tests\\ConnectionTest::Query"] == TestStatus.PASSED.value
+    assert result["Doctrine\\DBAL\\Tests\\ConnectionTest::Exec"] == TestStatus.FAILED.value
 
 
-def test_parse_log_phpunit_testdox_failed():
-    log = " ✘ Fetch associative"
+def test_parse_log_phpunit_testdox_multiple_classes():
+    log = (
+        "Connection (App\\Tests\\ATest)\n"
+        " ✔ Execute\n"
+        "\n"
+        "Statement (App\\Tests\\BTest)\n"
+        " ✔ Execute\n"
+    )
     result = parse_log_phpunit_testdox(log)
-    assert result["Fetch associative"] == TestStatus.FAILED.value
+    assert "App\\Tests\\ATest::Execute" in result
+    assert "App\\Tests\\BTest::Execute" in result
+    assert len(result) == 2
 
 
 def test_parse_log_phpunit_testdox_skipped():
-    log = " ↩ Some skipped test"
+    log = (
+        "Foo (App\\Tests\\FooTest)\n"
+        " ↩ Some skipped test"
+    )
     result = parse_log_phpunit_testdox(log)
-    assert result["Some skipped test"] == TestStatus.SKIPPED.value
+    assert result["App\\Tests\\FooTest::Some skipped test"] == TestStatus.SKIPPED.value
 
 
-def test_parse_log_phpunit_testdox_mixed():
-    log = " ✔ Test one\n ✘ Test two\n ↩ Test three\n ✔ Test four"
+def test_parse_log_phpunit_testdox_no_class_header():
+    log = " ✔ Bare test"
     result = parse_log_phpunit_testdox(log)
-    assert len(result) == 4
-    assert result["Test one"] == TestStatus.PASSED.value
-    assert result["Test two"] == TestStatus.FAILED.value
-    assert result["Test three"] == TestStatus.SKIPPED.value
-    assert result["Test four"] == TestStatus.PASSED.value
+    assert result["Bare test"] == TestStatus.PASSED.value
 
 
 def test_parse_log_phpunit_testdox_empty():
@@ -91,96 +100,48 @@ def test_parse_log_phpunit_testdox_empty():
     assert result == {}
 
 
-def test_parse_log_phpunit_verbose_passed():
-    log = " ✓ testPrepare\n ✓ testQuery"
-    result = parse_log_phpunit_verbose(log)
-    assert result["testPrepare"] == TestStatus.PASSED.value
-    assert result["testQuery"] == TestStatus.PASSED.value
-
-
-def test_parse_log_phpunit_verbose_failed():
-    log = " ✗ testFetchAssociative"
-    result = parse_log_phpunit_verbose(log)
-    assert result["testFetchAssociative"] == TestStatus.FAILED.value
-
-
-# --- Testdox name conversion tests ---
-
-
-def test_testdox_name_simple():
-    assert PhpProfile._testdox_name("testPrepare") == "Prepare"
-
-
-def test_testdox_name_camel_case():
-    assert PhpProfile._testdox_name("testGetServerVersion") == "Get server version"
-
-
-def test_testdox_name_multi_word():
-    assert PhpProfile._testdox_name("testFetchAssociative") == "Fetch associative"
-
-
-def test_testdox_name_consecutive_uppercase():
-    assert PhpProfile._testdox_name("testGetHTTPResponse") == "Get http response"
-
-
-# --- Build test name to files map tests ---
-
 
 def test_build_map_basic_test_file(tmp_path):
     _write_file(
         tmp_path,
         "tests/ConnectionTest.php",
-        "<?php\nclass ConnectionTest {\n    public function testPrepare() {}\n    public function testQuery() {}\n}\n",
+        "<?php\nnamespace App\\Tests;\nclass ConnectionTest {\n    public function testPrepare() {}\n}\n",
     )
     profile = _make_profile_with_clone(tmp_path)
-    result = profile._build_test_name_to_files_map()
-    assert "Prepare" in result
-    assert "tests/ConnectionTest.php" in result["Prepare"]
-    assert "Query" in result
-    assert "tests/ConnectionTest.php" in result["Query"]
+    result = profile._build_fqcn_to_file_map()
+    assert result["App\\Tests\\ConnectionTest"] == "tests/ConnectionTest.php"
 
 
-def test_build_map_without_public_modifier(tmp_path):
+def test_build_map_no_namespace(tmp_path):
     _write_file(
         tmp_path,
         "tests/FooTest.php",
         "<?php\nclass FooTest {\n    function testSomething() {}\n}\n",
     )
     profile = _make_profile_with_clone(tmp_path)
-    result = profile._build_test_name_to_files_map()
-    assert "Something" in result
-
-
-def test_build_map_camel_case_method(tmp_path):
-    _write_file(
-        tmp_path,
-        "tests/BarTest.php",
-        "<?php\nclass BarTest {\n    public function testGetServerVersion() {}\n}\n",
-    )
-    profile = _make_profile_with_clone(tmp_path)
-    result = profile._build_test_name_to_files_map()
-    assert "Get server version" in result
+    result = profile._build_fqcn_to_file_map()
+    assert result["FooTest"] == "tests/FooTest.php"
 
 
 def test_build_map_vendor_skipped(tmp_path):
     _write_file(
         tmp_path,
         "vendor/pkg/tests/SomeTest.php",
-        "<?php\nclass SomeTest {\n    public function testVendor() {}\n}\n",
+        "<?php\nnamespace Vendor\\Tests;\nclass SomeTest {}\n",
     )
     profile = _make_profile_with_clone(tmp_path)
-    result = profile._build_test_name_to_files_map()
-    assert "Vendor" not in result
+    result = profile._build_fqcn_to_file_map()
+    assert result == {}
 
 
 def test_build_map_non_test_file_ignored(tmp_path):
     _write_file(
         tmp_path,
         "src/Connection.php",
-        "<?php\nclass Connection {\n    public function testLike() {}\n}\n",
+        "<?php\nnamespace App;\nclass Connection {}\n",
     )
     profile = _make_profile_with_clone(tmp_path)
-    result = profile._build_test_name_to_files_map()
+    result = profile._build_fqcn_to_file_map()
     assert result == {}
 
 
@@ -188,44 +149,41 @@ def test_build_map_test_dir_convention(tmp_path):
     _write_file(
         tmp_path,
         "Test/Unit/Helper.php",
-        "<?php\nclass Helper {\n    public function testFormat() {}\n}\n",
+        "<?php\nnamespace App\\Test\\Unit;\nclass Helper {}\n",
     )
     profile = _make_profile_with_clone(tmp_path)
-    result = profile._build_test_name_to_files_map()
-    assert "Format" in result
+    result = profile._build_fqcn_to_file_map()
+    assert result["App\\Test\\Unit\\Helper"] == "Test/Unit/Helper.php"
 
 
-def test_build_map_same_name_multiple_files(tmp_path):
+def test_build_map_same_method_different_classes(tmp_path):
     _write_file(
         tmp_path,
         "tests/ATest.php",
-        "<?php\nclass ATest {\n    public function testExecute() {}\n}\n",
+        "<?php\nnamespace App\\Tests;\nclass ATest {\n    public function testExecute() {}\n}\n",
     )
     _write_file(
         tmp_path,
         "tests/BTest.php",
-        "<?php\nclass BTest {\n    public function testExecute() {}\n}\n",
+        "<?php\nnamespace App\\Tests;\nclass BTest {\n    public function testExecute() {}\n}\n",
     )
     profile = _make_profile_with_clone(tmp_path)
-    result = profile._build_test_name_to_files_map()
-    assert "Execute" in result
-    assert result["Execute"] == {"tests/ATest.php", "tests/BTest.php"}
+    result = profile._build_fqcn_to_file_map()
+    assert result["App\\Tests\\ATest"] == "tests/ATest.php"
+    assert result["App\\Tests\\BTest"] == "tests/BTest.php"
 
-
-# --- get_test_files tests ---
 
 
 def test_get_test_files_basic():
     cache = {
-        "Prepare": {"tests/ConnectionTest.php"},
-        "Query": {"tests/ConnectionTest.php"},
-        "Format output": {"tests/FormatterTest.php"},
+        "App\\Tests\\ConnectionTest": "tests/ConnectionTest.php",
+        "App\\Tests\\FormatterTest": "tests/FormatterTest.php",
     }
     profile = _make_profile_with_cache(cache)
     instance = {
         "instance_id": "dummy__dummyrepo.deadbeef.1",
-        "FAIL_TO_PASS": ["Prepare"],
-        "PASS_TO_PASS": ["Query", "Format output"],
+        "FAIL_TO_PASS": ["App\\Tests\\ConnectionTest::Prepare"],
+        "PASS_TO_PASS": ["App\\Tests\\ConnectionTest::Query", "App\\Tests\\FormatterTest::Format output"],
     }
     f2p, p2p = profile.get_test_files(instance)
     assert set(f2p) == {"tests/ConnectionTest.php"}
@@ -233,12 +191,12 @@ def test_get_test_files_basic():
 
 
 def test_get_test_files_missing_names():
-    cache = {"Prepare": {"tests/ConnectionTest.php"}}
+    cache = {"App\\Tests\\ConnectionTest": "tests/ConnectionTest.php"}
     profile = _make_profile_with_cache(cache)
     instance = {
         "instance_id": "dummy__dummyrepo.deadbeef.1",
-        "FAIL_TO_PASS": ["Not in cache"],
-        "PASS_TO_PASS": ["Also missing"],
+        "FAIL_TO_PASS": ["App\\Tests\\Missing::Not in cache"],
+        "PASS_TO_PASS": ["App\\Tests\\AlsoMissing::Also missing"],
     }
     f2p, p2p = profile.get_test_files(instance)
     assert f2p == []
@@ -273,8 +231,6 @@ def test_get_test_files_cache_reuse():
     assert clone_count == 1
 
 
-# --- Profile tests ---
-
 
 def test_dbal_dockerfile():
     profile = Dbalacb68b38()
@@ -304,16 +260,13 @@ def test_php_profile_defaults():
 
 def test_build_map_unreadable_file(tmp_path):
     """Files that can't be read (OSError/UnicodeDecodeError) are skipped."""
-    # Write a binary file that will cause UnicodeDecodeError
     test_dir = tmp_path / "tests"
     test_dir.mkdir()
     bad_file = test_dir / "BadTest.php"
-    bad_file.write_bytes(b"<?php\n\xff\xfe function testBad() {}\n")
+    bad_file.write_bytes(b"<?php\n\xff\xfe class BadTest {}\n")
 
     profile = _make_profile_with_clone(tmp_path)
-    result = profile._build_test_name_to_files_map()
-    # The file should be skipped due to decode error, but not crash
-    # It may or may not have results depending on whether the binary content is valid
+    result = profile._build_fqcn_to_file_map()
     assert isinstance(result, dict)
 
 
@@ -322,29 +275,23 @@ def test_build_map_test_prefixed_file(tmp_path):
     _write_file(
         tmp_path,
         "src/testHelper.php",
-        "<?php\nclass TestHelper {\n    public function testDoStuff() {}\n}\n",
+        "<?php\nclass TestHelper {}\n",
     )
     profile = _make_profile_with_clone(tmp_path)
-    result = profile._build_test_name_to_files_map()
-    assert "Do stuff" in result
-
-
-def test_testdox_name_no_test_prefix():
-    """Method name without 'test' prefix still gets camelCase splitting."""
-    assert PhpProfile._testdox_name("setUp") == "set up"
+    result = profile._build_fqcn_to_file_map()
+    assert result["TestHelper"] == "src/testHelper.php"
 
 
 def test_get_test_files_partial_cache_match():
     """Some test names in cache, some not."""
     cache = {
-        "Prepare": {"tests/ConnectionTest.php"},
-        "Query": {"tests/ConnectionTest.php"},
+        "App\\Tests\\ConnectionTest": "tests/ConnectionTest.php",
     }
     profile = _make_profile_with_cache(cache)
     instance = {
         "instance_id": "dummy__dummyrepo.deadbeef.1",
-        "FAIL_TO_PASS": ["Prepare", "Not in cache"],
-        "PASS_TO_PASS": ["Query", "Also missing"],
+        "FAIL_TO_PASS": ["App\\Tests\\ConnectionTest::Prepare", "App\\Tests\\Missing::Not in cache"],
+        "PASS_TO_PASS": ["App\\Tests\\ConnectionTest::Query", "App\\Tests\\AlsoMissing::Also missing"],
     }
     f2p, p2p = profile.get_test_files(instance)
     assert set(f2p) == {"tests/ConnectionTest.php"}

--- a/tests/profiles/test_profiles_php.py
+++ b/tests/profiles/test_profiles_php.py
@@ -130,7 +130,7 @@ def test_build_map_basic_test_file(tmp_path):
     _write_file(
         tmp_path,
         "tests/ConnectionTest.php",
-        '<?php\nclass ConnectionTest {\n    public function testPrepare() {}\n    public function testQuery() {}\n}\n',
+        "<?php\nclass ConnectionTest {\n    public function testPrepare() {}\n    public function testQuery() {}\n}\n",
     )
     profile = _make_profile_with_clone(tmp_path)
     result = profile._build_test_name_to_files_map()

--- a/tests/profiles/test_profiles_php.py
+++ b/tests/profiles/test_profiles_php.py
@@ -300,3 +300,52 @@ def test_php_profile_defaults():
     assert profile.org_dh == "swebench"
     assert profile.exts == [".php"]
     assert "phpunit" in profile.test_cmd
+
+
+def test_build_map_unreadable_file(tmp_path):
+    """Files that can't be read (OSError/UnicodeDecodeError) are skipped."""
+    # Write a binary file that will cause UnicodeDecodeError
+    test_dir = tmp_path / "tests"
+    test_dir.mkdir()
+    bad_file = test_dir / "BadTest.php"
+    bad_file.write_bytes(b"<?php\n\xff\xfe function testBad() {}\n")
+
+    profile = _make_profile_with_clone(tmp_path)
+    result = profile._build_test_name_to_files_map()
+    # The file should be skipped due to decode error, but not crash
+    # It may or may not have results depending on whether the binary content is valid
+    assert isinstance(result, dict)
+
+
+def test_build_map_test_prefixed_file(tmp_path):
+    """Files starting with 'test' should be picked up even outside tests/ dir."""
+    _write_file(
+        tmp_path,
+        "src/testHelper.php",
+        "<?php\nclass TestHelper {\n    public function testDoStuff() {}\n}\n",
+    )
+    profile = _make_profile_with_clone(tmp_path)
+    result = profile._build_test_name_to_files_map()
+    assert "Do stuff" in result
+
+
+def test_testdox_name_no_test_prefix():
+    """Method name without 'test' prefix still gets camelCase splitting."""
+    assert PhpProfile._testdox_name("setUp") == "set up"
+
+
+def test_get_test_files_partial_cache_match():
+    """Some test names in cache, some not."""
+    cache = {
+        "Prepare": {"tests/ConnectionTest.php"},
+        "Query": {"tests/ConnectionTest.php"},
+    }
+    profile = _make_profile_with_cache(cache)
+    instance = {
+        "instance_id": "dummy__dummyrepo.deadbeef.1",
+        "FAIL_TO_PASS": ["Prepare", "Not in cache"],
+        "PASS_TO_PASS": ["Query", "Also missing"],
+    }
+    f2p, p2p = profile.get_test_files(instance)
+    assert set(f2p) == {"tests/ConnectionTest.php"}
+    assert set(p2p) == {"tests/ConnectionTest.php"}

--- a/tests/profiles/test_profiles_php.py
+++ b/tests/profiles/test_profiles_php.py
@@ -4,7 +4,7 @@ import tempfile
 
 from swesmith.profiles.php import (
     PhpProfile,
-    Dbal,
+    Dbalacb68b38,
     Monolog6db20ca0,
     Guzzlefb92d95f,
     parse_log_phpunit_testdox,
@@ -277,7 +277,7 @@ def test_get_test_files_cache_reuse():
 
 
 def test_dbal_dockerfile():
-    profile = Dbal()
+    profile = Dbalacb68b38()
     assert "php:8.3" in profile.dockerfile
     assert f"/{ENV_NAME}" in profile.dockerfile
     assert "composer" in profile.dockerfile

--- a/tests/profiles/test_profiles_php.py
+++ b/tests/profiles/test_profiles_php.py
@@ -1,0 +1,302 @@
+import os
+import pytest
+import tempfile
+
+from swesmith.profiles.php import (
+    PhpProfile,
+    Dbal,
+    Monolog6db20ca0,
+    Guzzlefb92d95f,
+    parse_log_phpunit_testdox,
+    parse_log_phpunit_verbose,
+)
+from swesmith.constants import ENV_NAME
+from swebench.harness.constants import TestStatus
+
+
+def make_dummy_php_profile():
+    class DummyPhpProfile(PhpProfile):
+        owner = "dummy"
+        repo = "dummyrepo"
+        commit = "deadbeefcafebabe"
+
+        @property
+        def dockerfile(self):
+            return "FROM php:8.3\nRUN echo hello"
+
+        def log_parser(self, log):
+            return parse_log_phpunit_testdox(log)
+
+    return DummyPhpProfile()
+
+
+def _write_file(base, relpath, content):
+    full = os.path.join(base, relpath)
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, "w") as f:
+        f.write(content)
+
+
+def _make_profile_with_clone(tmp_path):
+    profile = make_dummy_php_profile()
+
+    def fake_clone(dest=None):
+        return str(tmp_path), False
+
+    profile.clone = fake_clone
+    return profile
+
+
+def _make_profile_with_cache(cache):
+    profile = make_dummy_php_profile()
+    profile._test_name_to_files_cache = cache
+    return profile
+
+
+# --- Log parser tests ---
+
+
+def test_parse_log_phpunit_testdox_passed():
+    log = " ✔ Prepare\n ✔ Query\n ✔ Exec"
+    result = parse_log_phpunit_testdox(log)
+    assert result["Prepare"] == TestStatus.PASSED.value
+    assert result["Query"] == TestStatus.PASSED.value
+    assert result["Exec"] == TestStatus.PASSED.value
+
+
+def test_parse_log_phpunit_testdox_failed():
+    log = " ✘ Fetch associative"
+    result = parse_log_phpunit_testdox(log)
+    assert result["Fetch associative"] == TestStatus.FAILED.value
+
+
+def test_parse_log_phpunit_testdox_skipped():
+    log = " ↩ Some skipped test"
+    result = parse_log_phpunit_testdox(log)
+    assert result["Some skipped test"] == TestStatus.SKIPPED.value
+
+
+def test_parse_log_phpunit_testdox_mixed():
+    log = " ✔ Test one\n ✘ Test two\n ↩ Test three\n ✔ Test four"
+    result = parse_log_phpunit_testdox(log)
+    assert len(result) == 4
+    assert result["Test one"] == TestStatus.PASSED.value
+    assert result["Test two"] == TestStatus.FAILED.value
+    assert result["Test three"] == TestStatus.SKIPPED.value
+    assert result["Test four"] == TestStatus.PASSED.value
+
+
+def test_parse_log_phpunit_testdox_empty():
+    result = parse_log_phpunit_testdox("")
+    assert result == {}
+
+
+def test_parse_log_phpunit_verbose_passed():
+    log = " ✓ testPrepare\n ✓ testQuery"
+    result = parse_log_phpunit_verbose(log)
+    assert result["testPrepare"] == TestStatus.PASSED.value
+    assert result["testQuery"] == TestStatus.PASSED.value
+
+
+def test_parse_log_phpunit_verbose_failed():
+    log = " ✗ testFetchAssociative"
+    result = parse_log_phpunit_verbose(log)
+    assert result["testFetchAssociative"] == TestStatus.FAILED.value
+
+
+# --- Testdox name conversion tests ---
+
+
+def test_testdox_name_simple():
+    assert PhpProfile._testdox_name("testPrepare") == "Prepare"
+
+
+def test_testdox_name_camel_case():
+    assert PhpProfile._testdox_name("testGetServerVersion") == "Get server version"
+
+
+def test_testdox_name_multi_word():
+    assert PhpProfile._testdox_name("testFetchAssociative") == "Fetch associative"
+
+
+def test_testdox_name_consecutive_uppercase():
+    assert PhpProfile._testdox_name("testGetHTTPResponse") == "Get http response"
+
+
+# --- Build test name to files map tests ---
+
+
+def test_build_map_basic_test_file(tmp_path):
+    _write_file(
+        tmp_path,
+        "tests/ConnectionTest.php",
+        '<?php\nclass ConnectionTest {\n    public function testPrepare() {}\n    public function testQuery() {}\n}\n',
+    )
+    profile = _make_profile_with_clone(tmp_path)
+    result = profile._build_test_name_to_files_map()
+    assert "Prepare" in result
+    assert "tests/ConnectionTest.php" in result["Prepare"]
+    assert "Query" in result
+    assert "tests/ConnectionTest.php" in result["Query"]
+
+
+def test_build_map_without_public_modifier(tmp_path):
+    _write_file(
+        tmp_path,
+        "tests/FooTest.php",
+        "<?php\nclass FooTest {\n    function testSomething() {}\n}\n",
+    )
+    profile = _make_profile_with_clone(tmp_path)
+    result = profile._build_test_name_to_files_map()
+    assert "Something" in result
+
+
+def test_build_map_camel_case_method(tmp_path):
+    _write_file(
+        tmp_path,
+        "tests/BarTest.php",
+        "<?php\nclass BarTest {\n    public function testGetServerVersion() {}\n}\n",
+    )
+    profile = _make_profile_with_clone(tmp_path)
+    result = profile._build_test_name_to_files_map()
+    assert "Get server version" in result
+
+
+def test_build_map_vendor_skipped(tmp_path):
+    _write_file(
+        tmp_path,
+        "vendor/pkg/tests/SomeTest.php",
+        "<?php\nclass SomeTest {\n    public function testVendor() {}\n}\n",
+    )
+    profile = _make_profile_with_clone(tmp_path)
+    result = profile._build_test_name_to_files_map()
+    assert "Vendor" not in result
+
+
+def test_build_map_non_test_file_ignored(tmp_path):
+    _write_file(
+        tmp_path,
+        "src/Connection.php",
+        "<?php\nclass Connection {\n    public function testLike() {}\n}\n",
+    )
+    profile = _make_profile_with_clone(tmp_path)
+    result = profile._build_test_name_to_files_map()
+    assert result == {}
+
+
+def test_build_map_test_dir_convention(tmp_path):
+    _write_file(
+        tmp_path,
+        "Test/Unit/Helper.php",
+        "<?php\nclass Helper {\n    public function testFormat() {}\n}\n",
+    )
+    profile = _make_profile_with_clone(tmp_path)
+    result = profile._build_test_name_to_files_map()
+    assert "Format" in result
+
+
+def test_build_map_same_name_multiple_files(tmp_path):
+    _write_file(
+        tmp_path,
+        "tests/ATest.php",
+        "<?php\nclass ATest {\n    public function testExecute() {}\n}\n",
+    )
+    _write_file(
+        tmp_path,
+        "tests/BTest.php",
+        "<?php\nclass BTest {\n    public function testExecute() {}\n}\n",
+    )
+    profile = _make_profile_with_clone(tmp_path)
+    result = profile._build_test_name_to_files_map()
+    assert "Execute" in result
+    assert result["Execute"] == {"tests/ATest.php", "tests/BTest.php"}
+
+
+# --- get_test_files tests ---
+
+
+def test_get_test_files_basic():
+    cache = {
+        "Prepare": {"tests/ConnectionTest.php"},
+        "Query": {"tests/ConnectionTest.php"},
+        "Format output": {"tests/FormatterTest.php"},
+    }
+    profile = _make_profile_with_cache(cache)
+    instance = {
+        "instance_id": "dummy__dummyrepo.deadbeef.1",
+        "FAIL_TO_PASS": ["Prepare"],
+        "PASS_TO_PASS": ["Query", "Format output"],
+    }
+    f2p, p2p = profile.get_test_files(instance)
+    assert set(f2p) == {"tests/ConnectionTest.php"}
+    assert set(p2p) == {"tests/ConnectionTest.php", "tests/FormatterTest.php"}
+
+
+def test_get_test_files_missing_names():
+    cache = {"Prepare": {"tests/ConnectionTest.php"}}
+    profile = _make_profile_with_cache(cache)
+    instance = {
+        "instance_id": "dummy__dummyrepo.deadbeef.1",
+        "FAIL_TO_PASS": ["Not in cache"],
+        "PASS_TO_PASS": ["Also missing"],
+    }
+    f2p, p2p = profile.get_test_files(instance)
+    assert f2p == []
+    assert p2p == []
+
+
+def test_get_test_files_assertion_error():
+    profile = _make_profile_with_cache({})
+    with pytest.raises(AssertionError):
+        profile.get_test_files({"instance_id": "dummy__dummyrepo.deadbeef.1"})
+
+
+def test_get_test_files_cache_reuse():
+    profile = make_dummy_php_profile()
+    clone_count = 0
+
+    def counting_clone(dest=None):
+        nonlocal clone_count
+        clone_count += 1
+        d = tempfile.mkdtemp()
+        return d, True
+
+    profile.clone = counting_clone
+
+    instance = {
+        "instance_id": "dummy__dummyrepo.deadbeef.1",
+        "FAIL_TO_PASS": ["test_a"],
+        "PASS_TO_PASS": ["test_b"],
+    }
+    profile.get_test_files(instance)
+    profile.get_test_files(instance)
+    assert clone_count == 1
+
+
+# --- Profile tests ---
+
+
+def test_dbal_dockerfile():
+    profile = Dbal()
+    assert "php:8.3" in profile.dockerfile
+    assert f"/{ENV_NAME}" in profile.dockerfile
+    assert "composer" in profile.dockerfile
+
+
+def test_monolog_dockerfile():
+    profile = Monolog6db20ca0()
+    assert "php:8.3" in profile.dockerfile
+    assert "ext-mongodb" in profile.dockerfile
+
+
+def test_guzzle_dockerfile():
+    profile = Guzzlefb92d95f()
+    assert "php:8.3" in profile.dockerfile
+    assert "composer install" in profile.dockerfile
+
+
+def test_php_profile_defaults():
+    profile = make_dummy_php_profile()
+    assert profile.org_dh == "swebench"
+    assert profile.exts == [".php"]
+    assert "phpunit" in profile.test_cmd

--- a/tests/profiles/test_profiles_php.py
+++ b/tests/profiles/test_profiles_php.py
@@ -52,7 +52,6 @@ def _make_profile_with_cache(cache):
     return profile
 
 
-
 def test_parse_log_phpunit_testdox_with_class_header():
     log = (
         "Connection (Doctrine\\DBAL\\Tests\\ConnectionTest)\n"
@@ -61,9 +60,17 @@ def test_parse_log_phpunit_testdox_with_class_header():
         " ✘ Exec"
     )
     result = parse_log_phpunit_testdox(log)
-    assert result["Doctrine\\DBAL\\Tests\\ConnectionTest::Prepare"] == TestStatus.PASSED.value
-    assert result["Doctrine\\DBAL\\Tests\\ConnectionTest::Query"] == TestStatus.PASSED.value
-    assert result["Doctrine\\DBAL\\Tests\\ConnectionTest::Exec"] == TestStatus.FAILED.value
+    assert (
+        result["Doctrine\\DBAL\\Tests\\ConnectionTest::Prepare"]
+        == TestStatus.PASSED.value
+    )
+    assert (
+        result["Doctrine\\DBAL\\Tests\\ConnectionTest::Query"]
+        == TestStatus.PASSED.value
+    )
+    assert (
+        result["Doctrine\\DBAL\\Tests\\ConnectionTest::Exec"] == TestStatus.FAILED.value
+    )
 
 
 def test_parse_log_phpunit_testdox_multiple_classes():
@@ -81,10 +88,7 @@ def test_parse_log_phpunit_testdox_multiple_classes():
 
 
 def test_parse_log_phpunit_testdox_skipped():
-    log = (
-        "Foo (App\\Tests\\FooTest)\n"
-        " ↩ Some skipped test"
-    )
+    log = "Foo (App\\Tests\\FooTest)\n ↩ Some skipped test"
     result = parse_log_phpunit_testdox(log)
     assert result["App\\Tests\\FooTest::Some skipped test"] == TestStatus.SKIPPED.value
 
@@ -98,7 +102,6 @@ def test_parse_log_phpunit_testdox_no_class_header():
 def test_parse_log_phpunit_testdox_empty():
     result = parse_log_phpunit_testdox("")
     assert result == {}
-
 
 
 def test_build_map_basic_test_file(tmp_path):
@@ -173,7 +176,6 @@ def test_build_map_same_method_different_classes(tmp_path):
     assert result["App\\Tests\\BTest"] == "tests/BTest.php"
 
 
-
 def test_get_test_files_basic():
     cache = {
         "App\\Tests\\ConnectionTest": "tests/ConnectionTest.php",
@@ -183,7 +185,10 @@ def test_get_test_files_basic():
     instance = {
         "instance_id": "dummy__dummyrepo.deadbeef.1",
         "FAIL_TO_PASS": ["App\\Tests\\ConnectionTest::Prepare"],
-        "PASS_TO_PASS": ["App\\Tests\\ConnectionTest::Query", "App\\Tests\\FormatterTest::Format output"],
+        "PASS_TO_PASS": [
+            "App\\Tests\\ConnectionTest::Query",
+            "App\\Tests\\FormatterTest::Format output",
+        ],
     }
     f2p, p2p = profile.get_test_files(instance)
     assert set(f2p) == {"tests/ConnectionTest.php"}
@@ -229,7 +234,6 @@ def test_get_test_files_cache_reuse():
     profile.get_test_files(instance)
     profile.get_test_files(instance)
     assert clone_count == 1
-
 
 
 def test_dbal_dockerfile():
@@ -290,8 +294,14 @@ def test_get_test_files_partial_cache_match():
     profile = _make_profile_with_cache(cache)
     instance = {
         "instance_id": "dummy__dummyrepo.deadbeef.1",
-        "FAIL_TO_PASS": ["App\\Tests\\ConnectionTest::Prepare", "App\\Tests\\Missing::Not in cache"],
-        "PASS_TO_PASS": ["App\\Tests\\ConnectionTest::Query", "App\\Tests\\AlsoMissing::Also missing"],
+        "FAIL_TO_PASS": [
+            "App\\Tests\\ConnectionTest::Prepare",
+            "App\\Tests\\Missing::Not in cache",
+        ],
+        "PASS_TO_PASS": [
+            "App\\Tests\\ConnectionTest::Query",
+            "App\\Tests\\AlsoMissing::Also missing",
+        ],
     }
     f2p, p2p = profile.get_test_files(instance)
     assert set(f2p) == {"tests/ConnectionTest.php"}


### PR DESCRIPTION
## Summary
- Add PHP language support with procedural bug generation using PHP-specific tree-sitter modifiers
- Implement 14 procedural modifiers (8 operation, 2 control flow, 4 remove) using PHP grammar
- Add `get_test_files()` for PhpProfile with PHPUnit testdox name-to-file mapping
- Include 3 PHP repo profiles: doctrine/dbal, guzzle/guzzle, Seldaek/monolog
- Add 59 tests (33 procedural modifier + 26 profile/log parser)

## Validation

Tested on 2 PHP repos and reached a **pass% of 35.4%** on average:

```
Repository          |   Gen |   Val |  Valid |  Pass%
----------------------------------------------------
doctrine/dbal       |  1099 |  1099 |    392 |  35.7%
Seldaek/monolog     |   916 |   916 |    322 |  35.2%
----------------------------------------------------
TOTAL               |  2015 |  2015 |    714 |  35.4%
----------------------------------------------------
MEAN                | 1007.5| 1007.5|  357.0 |  35.4%
STD                 |  129.4|  129.4|   49.5 |   0.4%
MIN                 |   916 |   916 |    322 |  35.2%
MEDIAN              | 1007.5| 1007.5|  357.0 |  35.4%
MAX                 |  1099 |  1099 |    392 |  35.7%
```

`func_pm_ternary_swap` and `func_pm_ctrl_invert_if` are the most productive modifiers in PHP. Operator and control flow mutations have higher pass rates since they introduce subtle behavioral bugs without breaking syntax.

```
Modifier                |   Gen |   Val |  Valid |  Pass%
---------------------------------------------------------
func_pm_arg_swap        |   187 |   187 |     71 |  38.0%
func_pm_aug_assign_swap |    39 |    39 |     19 |  48.7%
func_pm_ctrl_invert_if  |    61 |    61 |     30 |  49.2%
func_pm_ctrl_shuffle    |    73 |    73 |     21 |  28.8%
func_pm_op_break_chains |   137 |   137 |     43 |  31.4%
func_pm_op_change       |   100 |   100 |     44 |  44.0%
func_pm_op_change_const |   112 |   112 |     30 |  26.8%
func_pm_op_flip         |   299 |   299 |    107 |  35.8%
func_pm_op_swap         |   306 |   306 |     49 |  16.0%
func_pm_remove_assign   |   290 |   290 |    123 |  42.4%
func_pm_remove_cond     |   255 |   255 |    103 |  40.4%
func_pm_remove_loop     |   104 |   104 |     46 |  44.2%
func_pm_remove_ternary  |    26 |    26 |     12 |  46.2%
func_pm_ternary_swap    |    26 |    26 |     16 |  61.5%
---------------------------------------------------------
TOTAL                   |  2015 |  2015 |    714 |  35.4%
```

## Mirror & Task Branches

Task instance branches have been pushed to the mirror repos with the standard 2-commit structure (Initial commit + Bug Patch + Remove F2P Tests).

Example: [swesmith/Seldaek__monolog.6db20ca0 — func_pm_arg_swap__zwytedjj](https://github.com/swesmith/Seldaek__monolog.6db20ca0/compare/main...Seldaek__monolog.6db20ca0.func_pm_arg_swap__zwytedjj)