### PR TITLE
Fix hardcoded x86_64 platform in container creation (#arm64)

### DIFF
--- a/swesmith/harness/utils.py
+++ b/swesmith/harness/utils.py
@@ -147,7 +147,7 @@ def run_patch_in_container(
             user=DOCKER_USER,
             detach=True,
             command="tail -f /dev/null",
-            platform="linux/x86_64",
+            platform=rp.pltf,
             mem_limit="10g",
         )
         container.start()

--- a/swesmith/issue_gen/get_from_tests.py
+++ b/swesmith/issue_gen/get_from_tests.py
@@ -98,7 +98,7 @@ def run_command_in_container(instance: dict, command: str, rp: RepoProfile):
         user=DOCKER_USER,
         detach=True,
         command="tail -f /dev/null",
-        platform="linux/x86_64",
+        platform=rp.pltf,
         mem_limit="10g",
     )
     container.start()

--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -505,7 +505,7 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
             user=DOCKER_USER,
             detach=True,
             command="tail -f /dev/null",
-            platform="linux/x86_64",
+            platform=self.pltf,
             mem_limit="10g",
         )
         container.start()


### PR DESCRIPTION
Container creation in get_container(), run_patch_in_container(), and run_command_in_container() hardcoded platform="linux/x86_64", ignoring the host architecture detection already wired through RepoProfile.pltf.

On arm64/aarch64 hosts this forces Docker to either fail or fall back to QEMU x86 emulation, defeating native execution on Graviton and other arm64 systems.

Replace the three hardcoded strings with the existing self.pltf / rp.pltf property which resolves to "linux/arm64/v8" on arm64 and "linux/x86_64" on x86_64.

Tested: built and ran Python (addict, 128 tests) and Rust (rust-base64, 33 tests) SWE-smith containers natively on aarch64 with no QEMU.

Co-developed-by: Kiro (Amazon Q Developer Agent) <kiro-dev@amazon.com>