### PR TITLE
fix: setup.sh installs no dependencies — use 'uv sync --extra all'

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,4 +4,4 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 # Create and activate virtual environment
 uv venv --python 3.12
 source .venv/bin/activate
-uv sync
+uv sync --extra all


### PR DESCRIPTION
## What

One-line fix: `setup.sh` now runs `uv sync --extra all` instead of plain `uv sync`.

## Why

Following the README setup instructions:

```bash
git clone https://github.com/SWE-bench/SWE-smith
cd SWE-smith
./setup.sh
```

produces a virtual environment containing only the editable `swesmith` package and **zero dependencies**, so any subsequent command fails immediately:

```
$ python -m swesmith.build_repo.try_install_py Instagram/MonkeyType configs/install_repo.sh \
    --commit 70c3acf62950be5dfb28743c7a719bfdecebcd84
...
  File ".../swesmith/profiles/base.py", line 8, in <module>
    import docker
ModuleNotFoundError: No module named 'docker'
```

### Root cause

#192 (commit `6ace4b4`) moved all dependencies out of the base `dependencies` list into the `all` optional dependency group, to accommodate `modal.pip_install_from_pyproject`:

```toml
# Base dependencies are empty to allow granular dependency groups for Modal images
dependencies = []

[project.optional-dependencies]
all = [
    "astor",
    "datasets",
    "docker",
    ...
]
```

The same PR introduced `setup.sh` with a plain `uv sync`, which resolves the lockfile but installs nothing beyond the editable `swesmith` package — so the script has been broken since it was introduced.

## Verification

After this change, `uv sync --extra all` installs the full dependency set and both of these succeed in the fresh venv:

```python
import docker
from swesmith.profiles.python import PythonProfile
```

and the `try_install_py` command above runs past the import stage.
