### PR TITLE
fix: explicitly install pip when creating testbed env in install_repo.sh

### DIFF
--- a/configs/install_repo.sh
+++ b/configs/install_repo.sh
@@ -17,7 +17,7 @@ fi
 
 PYTHON_VERSION="${SWESMITH_PYTHON_VERSION:-3.10}"
 echo "> Creating conda env 'testbed' with python=${PYTHON_VERSION}"
-conda create -n testbed "python=${PYTHON_VERSION}" -yq
+conda create -n testbed "python=${PYTHON_VERSION}" pip -yq
 conda activate testbed
 
 echo "> Installing repo in editable mode"


### PR DESCRIPTION
## What

One-line fix: explicitly request `pip` when creating the `testbed` env in `configs/install_repo.sh`:

```diff
-conda create -n testbed "python=${PYTHON_VERSION}" -yq
+conda create -n testbed "python=${PYTHON_VERSION}" pip -yq
```

## Why

On conda installs where `add_pip_as_python_dependency` is `false` — which includes recent **miniforge** releases out of the box — `conda create -n testbed python=3.10` produces an environment **without pip**, and the very next line of the script fails:

```
++ python -m pip install -e .
/Users/.../envs/testbed/bin/python: No module named pip
> Installation procedure failed: Command '['bash', '-lc', '. .../configs/install_repo.sh']' returned non-zero exit status 1.
```

Background: conda-forge `python` packages no longer carry `pip` as a run dependency; whether pip lands in a fresh env is now decided by the client-side `add_pip_as_python_dependency` setting, which defaults to `false` in newer miniforge/conda builds. The script currently only works for users whose local conda happens to have the flag on (e.g. Anaconda/miniconda defaults).

Listing `pip` explicitly is a no-op where the flag is on, and fixes env construction everywhere else.

## Verification

Reproduced with miniforge 26.3.2 (flag off): script fails as above. With this change, `python -m swesmith.build_repo.try_install_py Instagram/MonkeyType configs/install_repo.sh --commit 70c3acf6` completes: repo installs, smoke test runs, env YAML is exported.

Related: #242 (another local env-construction fix in `setup.sh`).
