### PR TITLE
fix: docker build fails with passphrase-protected SSH keys — prefer ssh-agent

### DIFF
--- a/swesmith/profiles/base.py
+++ b/swesmith/profiles/base.py
@@ -195,6 +195,10 @@ class RepoProfile(ABC, metaclass=SingletonMeta):
 
     @property
     def _docker_ssh_arg(self) -> str:
+        # Prefer the ssh-agent: BuildKit cannot read passphrase-protected key
+        # files, and the agent serves those keys already decrypted.
+        if os.getenv("SSH_AUTH_SOCK"):
+            return "--ssh default"
         key_file = _find_ssh_key()
         if key_file:
             return f"--ssh default={key_file}"


### PR DESCRIPTION
## What

In `RepoProfile._docker_ssh_arg`, forward the ssh-agent (`--ssh default`) when `SSH_AUTH_SOCK` is set, instead of passing a private key file path to `docker build`.

## Why

`_docker_ssh_arg` currently passes the first key file found in `~/.ssh` as `--ssh default=<path>` whenever one exists — even for public repos that don't need SSH at all. If that key is **passphrase-protected** (a common and recommended setup), BuildKit rejects it at config-parse time and the build dies before doing anything:

```
$ python -m swesmith.build_repo.create_images -r MonkeyType
Error building swebench/swesmith.arm64.instagram_1776_monkeytype.70c3acf6: Command
'docker build ... --ssh default=/Users/me/.ssh/id_ed25519 -t ...' returned non-zero exit status 1.
```

`build_image.log`:

```
ERROR: failed to build: failed to convert agent config {default [/Users/me/.ssh/id_ed25519] false}:
failed to convert agent config for ID: "default":
failed to parse /Users/me/.ssh/id_ed25519: ssh: this private key is passphrase protected
```

BuildKit cannot prompt for a passphrase during a build. The standard mechanism for this case is `--ssh default` with no path, which forwards the host's ssh-agent — the agent serves keys already decrypted, so passphrase-protected keys work transparently, and private-repo clones inside the build keep working.

## Behavior change

- `SSH_AUTH_SOCK` set (typical interactive shells on macOS/Linux): forward the agent.
- No agent: unchanged — fall back to a discovered key file, then to `--ssh default` for private repos, then to no `--ssh` arg.

## Verification

With a passphrase-protected `~/.ssh/id_ed25519` (key loaded in the agent): `create_images -r MonkeyType` fails as above before the change, builds successfully after it.

Related: #242, #243 (other local env-construction/setup fixes).
